### PR TITLE
Add Swarm.Transports() getter

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -183,6 +183,10 @@ func (s *Swarm) AddTransport(t transport.Transport) {
 	s.transports = append(s.transports, t)
 }
 
+func (s *Swarm) Transports() []transport.Transport {
+	return s.transports
+}
+
 func (s *Swarm) teardown() error {
 	return s.swarm.Close()
 }

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -354,3 +354,29 @@ func TestFilterBounds(t *testing.T) {
 		t.Log("got connect")
 	}
 }
+
+func TestTransports(t *testing.T) {
+	ctx := context.Background()
+	s := makeSwarms(ctx, t, 1)[0]
+	laddr, _ := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+
+	lis, _ := s.Transports()[0].Listen(laddr)
+	expected := "/ip4/tcp"
+	actual := ""
+	for _, proto := range lis.Multiaddr().Protocols() {
+		actual = actual + "/" + proto.Name
+	}
+	if expected != actual {
+		t.Fatalf("expected %s, got %s", expected, actual)
+	}
+
+	lis, _ = s.Transports()[1].Listen(laddr)
+	expected = "/ip4/tcp/ws"
+	actual = ""
+	for _, proto := range lis.Multiaddr().Protocols() {
+		actual = actual + "/" + proto.Name
+	}
+	if expected != actual {
+		t.Fatalf("expected %s, got %s", expected, actual)
+	}
+}


### PR DESCRIPTION
This is so that the gateway can do some casting a la `n.PeerHost.Network().(*swarm.Network).Swarm()` and then get the transports, in order to grab the /ws transport, and mount its listener into the gateway http muxer.