### PR TITLE
Fix dialLimiter.fdConsuming counting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 language: go
 
 go:
-    - 1.7
+    - 1.8
 
 install: true
 


### PR DESCRIPTION
This fixes https://github.com/ipfs/go-ipfs/issues/4102

With this fix when running daemon SYN_SENT connections are hovering around 150-200, which is a huge improvement from around 3000.

Unit tests are TODO