### PR TITLE
gx: update base32

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.7.4: QmVJefKHXEx28RFpmj5GeRg43AqeBH3npPwvgJ875fBPm7
+1.7.5: QmbbVMqvNYYfSMS3Dh8RuHgKHibVCrbaMkc1rmEgEBGEzi

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmcYU4bjgs7dACwDWzfeYKgqkgbd5mKk2ZUCepYXhbtRSB",
+      "hash": "QmfZasE4nVF287V15M6wj43D86QQC2S6dK7CGK5dUVWDCK",
       "name": "go-libp2p-conn",
-      "version": "1.6.9"
+      "version": "1.6.10"
     },
     {
       "author": "whyrusleeping",
@@ -128,9 +128,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZJD56ZWLViJAVkvLc7xbbDerHzUMLr2X4fLRYfbxZWDN",
+      "hash": "QmUPhGaiqwLkwqLTa1QqgD9jwDkuMRSPdkgNhXuKBWiH7R",
       "name": "go-testutil",
-      "version": "1.1.10"
+      "version": "1.1.11"
     },
     {
       "author": "whyrusleeping",
@@ -174,6 +174,6 @@
   "license": "MIT",
   "name": "go-libp2p-swarm",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.7.4"
+  "version": "1.7.5"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/multiformats/go-multibase/pull/17
- https://github.com/ipfs/go-cid/pull/32
- https://github.com/libp2p/go-testutil/pull/11
- https://github.com/libp2p/go-libp2p-conn/pull/14
- https://github.com/libp2p/go-libp2p-connmgr/pull/4
- https://github.com/libp2p/go-libp2p-host/pull/7


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace