### PR TITLE
test: connect each peer precisely once.

### DIFF
--- a/swarm_test.go
+++ b/swarm_test.go
@@ -102,12 +102,10 @@ func connectSwarms(t *testing.T, ctx context.Context, swarms []*Swarm) {
 	}
 
 	log.Info("Connecting swarms simultaneously.")
-	for _, s1 := range swarms {
-		for _, s2 := range swarms {
-			if s2.local != s1.local { // don't connect to self.
-				wg.Add(1)
-				connect(s1, s2.LocalPeer(), s2.ListenAddresses()[0]) // try the first.
-			}
+	for i, s1 := range swarms {
+		for _, s2 := range swarms[i+1:] {
+			wg.Add(1)
+			connect(s1, s2.LocalPeer(), s2.ListenAddresses()[0]) // try the first.
 		}
 	}
 	wg.Wait()


### PR DESCRIPTION
Otherwise, some tests will get confused by duplicate (temporary, we close duplicates quickly) connections.

fixes libp2p/go-libp2p#100