### PR TITLE
Issue #370 Check if empty peer ID

### DIFF
--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -183,6 +183,11 @@ func (s *Swarm) DialPeer(ctx context.Context, p peer.ID) (inet.Conn, error) {
 func (s *Swarm) dialPeer(ctx context.Context, p peer.ID) (*Conn, error) {
 	log.Debugf("[%s] swarm dialing peer [%s]", s.local, p)
 	var logdial = lgbl.Dial("swarm", s.LocalPeer(), p, nil, nil)
+	err := p.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	if p == s.local {
 		log.Event(ctx, "swarmDialSelf", logdial)
 		return nil, ErrDialToSelf
@@ -206,7 +211,7 @@ func (s *Swarm) dialPeer(ctx context.Context, p peer.ID) (*Conn, error) {
 	ctx, cancel := context.WithTimeout(ctx, inet.GetDialPeerTimeout(ctx))
 	defer cancel()
 
-	conn, err := s.dsync.DialLock(ctx, p)
+	conn, err = s.dsync.DialLock(ctx, p)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On trying to open a new stream against an empty peer ID, we get an
error saying that failed to dial a peer.

This commit changes that to a more informative error message:
`empty peer ID`

Part of the fix for https://github.com/libp2p/go-libp2p/issues/370