### PR TITLE
Improve error messages when remote addresses are bad

### DIFF
--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -385,7 +385,11 @@ func (s *Swarm) dialAddrs(ctx context.Context, p peer.ID, remoteAddrs <-chan ma.
 			}
 		}
 	}
-	return nil, errors.New("no remote addresses")
+	if lastDialErr != nil {
+		return nil, lastDialErr
+	} else {
+		return nil, errors.New("no remote addresses")
+	}
 }
 
 // limitedDial will start a dial to the given peer when

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -364,16 +364,14 @@ func (s *Swarm) dialAddrs(ctx context.Context, p peer.ID, remoteAddrs <-chan ma.
 			// no dials succeed.
 			lastDialErr = dr.Err
 			return false
-		} else {
-			return true
 		}
+		return true
 	}
 	ctxDoneRetErr := func() error {
 		if lastDialErr != nil {
 			return lastDialErr
-		} else {
-			return ctx.Err()
 		}
+		return ctx.Err()
 	}
 	for remoteAddrs != nil || activeDials > 0 {
 		// Try to proceed on context completion or a dial result before dialing
@@ -384,9 +382,8 @@ func (s *Swarm) dialAddrs(ctx context.Context, p peer.ID, remoteAddrs <-chan ma.
 		case dr := <-dialResults:
 			if onDialResult(dr) {
 				return dr.Conn, nil
-			} else {
-				continue
 			}
+			continue
 		default:
 		}
 		select {
@@ -407,11 +404,10 @@ func (s *Swarm) dialAddrs(ctx context.Context, p peer.ID, remoteAddrs <-chan ma.
 	}
 	if lastDialErr != nil {
 		return nil, lastDialErr
-	} else {
-		// If there were no dial errors and we didn't return due to context
-		// completion than we had no addresses to begin with.
-		return nil, errors.New("no remote addresses")
 	}
+	// If there were no dial errors and we didn't return due to context
+	// completion than we had no addresses to begin with.
+	return nil, inet.ErrNoRemoteAddrs
 }
 
 // limitedDial will start a dial to the given peer when

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -346,7 +346,7 @@ func (s *Swarm) filterKnownUndialables(addrs []ma.Multiaddr) []ma.Multiaddr {
 	)
 }
 
-func (s *Swarm) dialAddrs(ctx context.Context, p peer.ID, remoteAddrs <-chan ma.Multiaddr) (conn transport.Conn, err error) {
+func (s *Swarm) dialAddrs(ctx context.Context, p peer.ID, remoteAddrs <-chan ma.Multiaddr) (transport.Conn, error) {
 	log.Debugf("%s swarm dialing %s", s.local, p)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -349,63 +349,46 @@ func (s *Swarm) filterKnownUndialables(addrs []ma.Multiaddr) []ma.Multiaddr {
 func (s *Swarm) dialAddrs(ctx context.Context, p peer.ID, remoteAddrs <-chan ma.Multiaddr) (transport.Conn, error) {
 	log.Debugf("%s swarm dialing %s", s.local, p)
 
-	subCtx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel() // cancel work when we exit func
 
-	var (
-		mu          sync.Mutex
-		active      int
-		noMoreDials bool
+	dialResults := make(chan dialResult)
 
-		dialResults = make(chan dialResult)
-	)
-	go func() {
-		defer func() {
-			s.limiter.clearAllPeerDials(p)
-			mu.Lock()
-			noMoreDials = true
-			mu.Unlock()
-		}()
-		for {
-			if subCtx.Err() != nil {
-				return
-			}
-			select {
-			case addr, ok := <-remoteAddrs:
-				if !ok {
-					return
-				}
-				mu.Lock()
-				active++
-				s.limitedDial(subCtx, p, addr, dialResults)
-				mu.Unlock()
-			case <-subCtx.Done():
-			}
-		}
-	}()
-	for {
-		mu.Lock()
-		if active == 0 && noMoreDials {
-			mu.Unlock()
-			return nil, ctx.Err()
-		}
-		mu.Unlock()
+	var lastDialErr error
+
+	defer s.limiter.clearAllPeerDials(p)
+
+	var active int
+	for remoteAddrs != nil || active > 0 {
 		select {
-		case dr := <-dialResults:
-			if dr.Err == nil {
-				return dr.Conn, nil
+		case addr, ok := <-remoteAddrs:
+			if !ok {
+				remoteAddrs = nil
+				continue
 			}
-			log.Infof("error dialing %v: %v", dr.Addr, dr.Err)
-			mu.Lock()
-			active--
-			if active == 0 && noMoreDials {
-				mu.Unlock()
-				return nil, dr.Err
-			}
-			mu.Unlock()
+			s.limitedDial(ctx, p, addr, dialResults)
+			active++
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			if lastDialErr != nil {
+				return nil, lastDialErr
+			} else {
+				return nil, ctx.Err()
+			}
+		case resp := <-dialResults:
+			active--
+			if resp.Err != nil {
+				log.Infof("got error on dial to %s: %s", resp.Addr, resp.Err)
+				// Errors are normal, lots of dials will fail
+				lastDialErr = resp.Err
+			} else {
+				return resp.Conn, nil
+			}
 		}
+	}
+	if lastDialErr != nil {
+		return nil, lastDialErr
+	} else {
+		return nil, errors.New("no remote addresses")
 	}
 }
 


### PR DESCRIPTION
Improves the error message when there are no addresses because they're all filtered out, or none are given. Also the dial logic is simplified. Timing, and pseudo-random channel operations make optimistic selects unworthwhile.