### PR TITLE
Trivial context and comments

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -27,12 +27,7 @@ type dialJob struct {
 }
 
 func (dj *dialJob) cancelled() bool {
-	select {
-	case <-dj.ctx.Done():
-		return true
-	default:
-		return false
-	}
+	return dj.ctx.Err() != nil
 }
 
 func (dj *dialJob) dialTimeout() time.Duration {

--- a/swarm.go
+++ b/swarm.go
@@ -121,8 +121,8 @@ func (s *Swarm) teardown() error {
 	s.conns.m = nil
 	s.conns.Unlock()
 
-	// Lots of go routines but we might as well do this in parallel. We want
-	// to shut down as fast as possible.
+	// Lots of goroutines but we might as well do this in parallel. We want to shut down as fast as
+	// possible.
 
 	for l := range listeners {
 		go func(l transport.Listener) {
@@ -148,8 +148,8 @@ func (s *Swarm) teardown() error {
 	return nil
 }
 
-// AddAddrFilter adds a multiaddr filter to the set of filters the swarm will
-// use to determine which addresses not to dial to.
+// AddAddrFilter adds a multiaddr filter to the set of filters the swarm will use to determine which
+// addresses not to dial to.
 func (s *Swarm) AddAddrFilter(f string) error {
 	m, err := mafilter.NewMask(f)
 	if err != nil {

--- a/swarm.go
+++ b/swarm.go
@@ -208,9 +208,6 @@ func (s *Swarm) addConn(tc transport.Conn, dir inet.Direction) (*Conn, error) {
 	// * The other will be decremented when Conn.start exits.
 	s.refs.Add(2)
 
-	// Take the notification lock before releasing the conns lock to block
-	// Disconnect notifications until after the Connect notifications done.
-	c.notifyLk.Lock()
 	s.conns.Unlock()
 
 	// We have a connection now. Cancel all other in-progress dials.
@@ -220,7 +217,6 @@ func (s *Swarm) addConn(tc transport.Conn, dir inet.Direction) (*Conn, error) {
 	s.notifyAll(func(f inet.Notifiee) {
 		f.Connected(s, c)
 	})
-	c.notifyLk.Unlock()
 
 	c.start()
 
@@ -438,18 +434,10 @@ func (s *Swarm) Backoff() *DialBackoff {
 
 // notifyAll sends a signal to all Notifiees
 func (s *Swarm) notifyAll(notify func(inet.Notifiee)) {
-	var wg sync.WaitGroup
-
 	s.notifs.RLock()
-	wg.Add(len(s.notifs.m))
 	for f := range s.notifs.m {
-		go func(f inet.Notifiee) {
-			defer wg.Done()
-			notify(f)
-		}(f)
+		notify(f)
 	}
-
-	wg.Wait()
 	s.notifs.RUnlock()
 }
 

--- a/swarm_conn.go
+++ b/swarm_conn.go
@@ -65,17 +65,10 @@ func (c *Conn) doClose() {
 		s.Reset()
 	}
 
-	// do this in a goroutine to avoid deadlocking if we call close in an open notification.
-	go func() {
-		// prevents us from issuing close notifications before finishing the open notifications
-		c.notifyLk.Lock()
-		defer c.notifyLk.Unlock()
-
-		c.swarm.notifyAll(func(f inet.Notifiee) {
-			f.Disconnected(c.swarm, c)
-		})
-		c.swarm.refs.Done() // taken in Swarm.addConn
-	}()
+	c.swarm.notifyAll(func(f inet.Notifiee) {
+		f.Disconnected(c.swarm, c)
+	})
+	c.swarm.refs.Done() // taken in Swarm.addConn
 }
 
 func (c *Conn) removeStream(s *Stream) {

--- a/swarm_conn.go
+++ b/swarm_conn.go
@@ -65,10 +65,17 @@ func (c *Conn) doClose() {
 		s.Reset()
 	}
 
-	c.swarm.notifyAll(func(f inet.Notifiee) {
-		f.Disconnected(c.swarm, c)
-	})
-	c.swarm.refs.Done() // taken in Swarm.addConn
+	// do this in a goroutine to avoid deadlocking if we call close in an open notification.
+	go func() {
+		// prevents us from issuing close notifications before finishing the open notifications
+		c.notifyLk.Lock()
+		defer c.notifyLk.Unlock()
+
+		c.swarm.notifyAll(func(f inet.Notifiee) {
+			f.Disconnected(c.swarm, c)
+		})
+		c.swarm.refs.Done() // taken in Swarm.addConn
+	}()
 }
 
 func (c *Conn) removeStream(s *Stream) {

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -275,7 +275,7 @@ func (s *Swarm) dial(ctx context.Context, p peer.ID) (*Conn, error) {
 	logdial["dial"] = "failure" // start off with failure. set to "success" at the end.
 
 	sk := s.peers.PrivKey(s.local)
-	logdial["encrypted"] = (sk != nil) // log wether this will be an encrypted dial or not.
+	logdial["encrypted"] = sk != nil // log whether this will be an encrypted dial or not.
 	if sk == nil {
 		// fine for sk to be nil, just log.
 		log.Debug("Dial not given PrivateKey, so WILL NOT SECURE conn.")

--- a/swarm_listen.go
+++ b/swarm_listen.go
@@ -74,7 +74,9 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 		for {
 			c, err := list.Accept()
 			if err != nil {
-				log.Warningf("swarm listener accept error: %s", err)
+				if s.ctx.Err() == nil {
+					log.Errorf("swarm listener accept error: %s", err)
+				}
 				return
 			}
 			log.Debugf("swarm listener accepted connection: %s", c)


### PR DESCRIPTION
I've noticed a lot of locks around to ensure notification ordering. I think it's much superior to do synchronous notifications and allow consumers to decide for themselves how to handle concurrency. I've tested this significantly with the DHT, where it also provides for a lot of simplification. There is a fair bit of notification flow where go routines are spawned at each handler step, as an example.