### PR TITLE
Differentiate no addresses error from no good addresses

### DIFF
--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -248,7 +248,7 @@ func (s *Swarm) doDial(ctx context.Context, p peer.ID) (*Conn, error) {
 			log.Debugf("ignoring dial error because we have a connection: %s", err)
 			return conn, nil
 		}
-		if ctx.Err() == nil {
+		if err != context.Canceled {
 			log.Event(ctx, "swarmDialBackoffAdd", logdial)
 			s.backf.AddBackoff(p) // let others know to backoff
 		}

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -84,7 +84,7 @@ const DefaultPerPeerRateLimit = 8
 
 // DialBackoff is a type for tracking peer dial backoffs.
 //
-// * It's safe to use it's zero value.
+// * It's safe to use its zero value.
 // * It's thread-safe.
 // * It's *not* safe to move this type after using.
 type DialBackoff struct {
@@ -248,7 +248,7 @@ func (s *Swarm) doDial(ctx context.Context, p peer.ID) (*Conn, error) {
 			log.Debugf("ignoring dial error because we have a connection: %s", err)
 			return conn, nil
 		}
-		if err != context.Canceled {
+		if ctx.Err() == nil {
 			log.Event(ctx, "swarmDialBackoffAdd", logdial)
 			s.backf.AddBackoff(p) // let others know to backoff
 		}

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -289,7 +289,11 @@ func (s *Swarm) dial(ctx context.Context, p peer.ID) (*Conn, error) {
 		the improved rate limiter, while maintaining the outward behaviour
 		that we previously had (halting a dial when we run out of addrs)
 	*/
-	goodAddrs := s.filterKnownUndialables(s.peers.Addrs(p))
+	peerAddrs := s.peers.Addrs(p)
+	if len(peerAddrs) == 0 {
+		return nil, errors.New("no addresses")
+	}
+	goodAddrs := s.filterKnownUndialables(peerAddrs)
 	if len(goodAddrs) == 0 {
 		return nil, errors.New("no good addresses")
 	}


### PR DESCRIPTION
Address filtering is applied before considering returning an error. This adds an extra error if there are no addresses at all to differentiate this. I found this useful as sometimes addresses are filtered for having trailing /p2p components, which was confusing. A later PR may improve that too.

The error check is changed to determine if the backoff could be part of context completion, as opposed to returned by an arbitrary downstream context (but not part of the current context), which I believe to the real intention.