### PR TITLE
Add context option to disable dialing when opening a new stream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/libp2p/go-libp2p-crypto v0.0.1
 	github.com/libp2p/go-libp2p-loggables v0.0.1
 	github.com/libp2p/go-libp2p-metrics v0.0.1
-	github.com/libp2p/go-libp2p-net v0.0.1
+	github.com/libp2p/go-libp2p-net v0.0.2
 	github.com/libp2p/go-libp2p-peer v0.0.1
 	github.com/libp2p/go-libp2p-peerstore v0.0.1
 	github.com/libp2p/go-libp2p-protocol v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/libp2p/go-libp2p-metrics v0.0.1 h1:yumdPC/P2VzINdmcKZd0pciSUCpou+s0lw
 github.com/libp2p/go-libp2p-metrics v0.0.1/go.mod h1:jQJ95SXXA/K1VZi13h52WZMa9ja78zjyy5rspMsC/08=
 github.com/libp2p/go-libp2p-net v0.0.1 h1:xJ4Vh4yKF/XKb8fd1Ev0ebAGzVjMxXzrxG2kjtU+F5Q=
 github.com/libp2p/go-libp2p-net v0.0.1/go.mod h1:Yt3zgmlsHOgUWSXmt5V/Jpz9upuJBE8EgNU9DrCcR8c=
+github.com/libp2p/go-libp2p-net v0.0.2 h1:qP06u4TYXfl7uW/hzqPhlVVTSA2nw1B/bHBJaUnbh6M=
+github.com/libp2p/go-libp2p-net v0.0.2/go.mod h1:Yt3zgmlsHOgUWSXmt5V/Jpz9upuJBE8EgNU9DrCcR8c=
 github.com/libp2p/go-libp2p-peer v0.0.1 h1:0qwAOljzYewINrU+Kndoc+1jAL7vzY/oY2Go4DCGfyY=
 github.com/libp2p/go-libp2p-peer v0.0.1/go.mod h1:nXQvOBbwVqoP+T5Y5nCjeH4sP9IX/J0AMzcDUVruVoo=
 github.com/libp2p/go-libp2p-peerstore v0.0.1 h1:twKovq8YK5trLrd3nB7PD2Zu9JcyAIdm7Bz9yBWjhq8=

--- a/swarm.go
+++ b/swarm.go
@@ -37,18 +37,6 @@ var ErrSwarmClosed = errors.New("swarm closed")
 // transport is misbehaving.
 var ErrAddrFiltered = errors.New("address filtered")
 
-// ErrNoConn is returned when attempting to open a stream to a peer with the NoDial
-// option and no usable connection is available.
-var ErrNoConn = errors.New("no usable connection to peer")
-
-// ContextOption is the type of context options understood by the swarm
-type ContextOption string
-
-// NoDial is a context option that instructs the swarm to not attempt a new
-// dial when opening a stream. The value of the key should be a string indicating
-// the source of the option.
-var NoDial = ContextOption("swarm.NoDial")
-
 // Swarm is a connection muxer, allowing connections to other peers to
 // be opened and closed, while still using the same Chan for all
 // communication. The Chan sends/receives Messages, which note the
@@ -307,8 +295,8 @@ func (s *Swarm) NewStream(ctx context.Context, p peer.ID) (inet.Stream, error) {
 	for {
 		c := s.bestConnToPeer(p)
 		if c == nil {
-			if nodial := ctx.Value(NoDial); nodial != nil {
-				return nil, ErrNoConn
+			if nodial, _ := inet.GetNoDial(ctx); nodial {
+				return nil, inet.ErrNoConn
 			}
 
 			if dials >= DialAttempts {

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -50,6 +50,7 @@ func EchoStreamHandler(stream inet.Stream) {
 				return
 			}
 		}
+
 	}()
 }
 
@@ -333,5 +334,15 @@ func TestFilterBounds(t *testing.T) {
 		t.Fatal("should have gotten connection")
 	case <-conns:
 		t.Log("got connect")
+	}
+}
+
+func TestNoDial(t *testing.T) {
+	ctx := context.Background()
+	swarms := makeSwarms(ctx, t, 2)
+
+	_, err := swarms[0].NewStream(context.WithValue(ctx, NoDial, "swarm.test"), swarms[1].LocalPeer())
+	if err != ErrNoConn {
+		t.Fatal("should have failed with ErrNoConn")
 	}
 }

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -50,7 +50,6 @@ func EchoStreamHandler(stream inet.Stream) {
 				return
 			}
 		}
-
 	}()
 }
 

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -341,8 +341,8 @@ func TestNoDial(t *testing.T) {
 	ctx := context.Background()
 	swarms := makeSwarms(ctx, t, 2)
 
-	_, err := swarms[0].NewStream(context.WithValue(ctx, NoDial, "swarm.test"), swarms[1].LocalPeer())
-	if err != ErrNoConn {
+	_, err := swarms[0].NewStream(inet.WithNoDial(ctx, "swarm test"), swarms[1].LocalPeer())
+	if err != inet.ErrNoConn {
 		t.Fatal("should have failed with ErrNoConn")
 	}
 }


### PR DESCRIPTION
This is essential for (non active) relays who under no circumstances want to initiate a dial to a peer.

It was necessitated by the discovery of a large number of goroutines doing recursive dialing in a relay.