### PR TITLE
dial: return a nice custom dial error

### DIFF
--- a/dial_error.go
+++ b/dial_error.go
@@ -1,0 +1,69 @@
+package swarm
+
+import (
+	"fmt"
+	"strings"
+
+	peer "github.com/libp2p/go-libp2p-peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// maxDialDialErrors is the maximum number of dial errors we record
+const maxDialDialErrors = 16
+
+// DialError is the error type returned when dialing.
+type DialError struct {
+	Peer       peer.ID
+	DialErrors []TransportError
+	Cause      error
+	Skipped    int
+}
+
+func (e *DialError) recordErr(addr ma.Multiaddr, err error) {
+	if len(e.DialErrors) >= maxDialDialErrors {
+		e.Skipped++
+		return
+	}
+	e.DialErrors = append(e.DialErrors, TransportError{
+		Address: addr,
+		Cause:   err,
+	})
+}
+
+func (e *DialError) Error() string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "failed to dial %s:", e.Peer)
+	if e.Cause != nil {
+		fmt.Fprintf(&builder, " %s", e.Cause)
+	}
+	for _, te := range e.DialErrors {
+		fmt.Fprintf(&builder, "\n  * [%s] %s", te.Address, te.Cause)
+	}
+	if e.Skipped > 0 {
+		fmt.Fprintf(&builder, "\n    ... skipping %d errors ...", e.Skipped)
+	}
+	return builder.String()
+}
+
+// Unwrap implements https://godoc.org/golang.org/x/xerrors#Wrapper.
+func (e *DialError) Unwrap() error {
+	// If we have a context error, that's the "ultimate" error.
+	if e.Cause != nil {
+		return e.Cause
+	}
+	return nil
+}
+
+var _ error = (*DialError)(nil)
+
+// TransportError is the error returned when dialing a specific address.
+type TransportError struct {
+	Address ma.Multiaddr
+	Cause   error
+}
+
+func (e *TransportError) Error() string {
+	return fmt.Sprintf("failed to dial %s: %s", e.Address, e.Cause)
+}
+
+var _ error = (*TransportError)(nil)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/libp2p/go-libp2p-swarm
 
 require (
-	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ipfs/go-log v0.0.1
 	github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8
 	github.com/libp2p/go-addr-util v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -31,10 +31,6 @@ github.com/gxed/hashland/keccakpg v0.0.1 h1:wrk3uMNaMxbXiHibbPO4S0ymqJMm41WiudyF
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1 h1:SheiaIt0sda5K+8FLz952/1iWS9zrnKsEJaOJu4ZbSc=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
-github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
* Limits the number of dial errors we keep
* Exposes the dial errors
* Avoids string formatting unless we actually need to.

Helps address https://github.com/libp2p/go-libp2p-swarm/issues/119
Alternative to: https://github.com/libp2p/go-libp2p-swarm/pull/120