### PR TITLE
don't call the "connection handler" for outbound connections

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -236,13 +236,6 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 
 	c.start()
 
-	// TODO: Get rid of this. We use it for identify but that happen much
-	// earlier (really, inside the transport and, if not then, during the
-	// notifications).
-	if h := s.ConnHandler(); h != nil {
-		go h(c)
-	}
-
 	return c, nil
 }
 

--- a/swarm_listen.go
+++ b/swarm_listen.go
@@ -88,7 +88,7 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 			s.refs.Add(1)
 			go func() {
 				defer s.refs.Done()
-				_, err := s.addConn(c, network.DirInbound)
+				c, err := s.addConn(c, network.DirInbound)
 				switch err {
 				case nil:
 				case ErrSwarmClosed:
@@ -97,6 +97,14 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 				default:
 					log.Warningf("add conn %s failed: ", err)
 					return
+				}
+
+				// TODO: Get rid of this. We use it for identify
+				// but that should happen much earlier (really,
+				// inside the transport and, if not then, during
+				// the notifications).
+				if h := s.ConnHandler(); h != nil {
+					go h(c)
 				}
 			}()
 		}


### PR DESCRIPTION
"oops"

This was never supposed to happen. However, it looks like this has been happening forever. Should we just update the documentation?

If we do that, we should fix the basic host to not call identify from `Connect`.