### PR TITLE
fix: don't assume that transports implement stringer

### DIFF
--- a/swarm_conn.go
+++ b/swarm_conn.go
@@ -122,7 +122,7 @@ func (c *Conn) start() {
 
 func (c *Conn) String() string {
 	return fmt.Sprintf(
-		"<swarm.Conn[%s] %s (%s) <-> %s (%s)>",
+		"<swarm.Conn[%T] %s (%s) <-> %s (%s)>",
 		c.conn.Transport(),
 		c.conn.LocalMultiaddr(),
 		c.conn.LocalPeer().Pretty(),


### PR DESCRIPTION
If they don't, this could end up reading a bunch of internal data, causing a race (and yes, this has happened).