### PR TITLE
Test Swarm Peerstore goroutine leak

### DIFF
--- a/testing/testing.go
+++ b/testing/testing.go
@@ -73,6 +73,13 @@ func GenSwarm(t *testing.T, ctx context.Context, opts ...Option) *swarm.Swarm {
 	ps.AddPrivKey(p.ID, p.PrivKey)
 	s := swarm.NewSwarm(ctx, p.ID, ps, metrics.NewBandwidthCounter())
 
+	// Close the peerstore when context is expired
+	// TODO: the peerstore should really take a context instead
+	go func() {
+		<-ctx.Done()
+		ps.Close()
+	}()
+
 	tcpTransport := tcp.NewTCPTransport(GenUpgrader(s))
 	tcpTransport.DisableReuseport = cfg.disableReuseport
 


### PR DESCRIPTION
The test swarm currently leaks goroutines by creating an in memory peerstore and not closing it.

As mentioned in libp2p/go-libp2p#718 we may want to have the swarm close the peerstore when the swarm gets closed, or at the very least the in memory peerstore should take a context just like the datastore peerstore does.

This circumvents the problem for now by just adding another goroutine that kills off the peerstore when the context passed into the test swarm creation is cancelled.