### PR TITLE
Swarm should publish stream/peer connection events to eventbus & deprecate Notifiee

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ require (
 	github.com/jbenet/goprocess v0.1.3
 	github.com/libp2p/go-addr-util v0.0.1
 	github.com/libp2p/go-conn-security-multistream v0.1.0
-	github.com/libp2p/go-libp2p-core v0.2.2
+	github.com/libp2p/go-eventbus v0.1.0
+	github.com/libp2p/go-libp2p-core v0.2.3-0.20190913134417-43e3c9c85923
 	github.com/libp2p/go-libp2p-loggables v0.1.0
 	github.com/libp2p/go-libp2p-peerstore v0.1.3
 	github.com/libp2p/go-libp2p-secio v0.2.0
@@ -18,6 +19,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.1.1
 	github.com/multiformats/go-multiaddr-fmt v0.1.0
 	github.com/multiformats/go-multiaddr-net v0.1.0
+	github.com/stretchr/testify v1.3.0
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOS
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
 github.com/libp2p/go-conn-security-multistream v0.1.0 h1:aqGmto+ttL/uJgX0JtQI0tD21CIEy5eYd1Hlp0juHY0=
 github.com/libp2p/go-conn-security-multistream v0.1.0/go.mod h1:aw6eD7LOsHEX7+2hJkDxw1MteijaVcI+/eP2/x3J1xc=
+github.com/libp2p/go-eventbus v0.1.0 h1:mlawomSAjjkk97QnYiEmHsLu7E136+2oCWSHRUvMfzQ=
+github.com/libp2p/go-eventbus v0.1.0/go.mod h1:vROgu5cs5T7cv7POWlWxBaVLxfSegC5UGQf8A2eEmx4=
 github.com/libp2p/go-flow-metrics v0.0.1 h1:0gxuFd2GuK7IIP5pKljLwps6TvcuYgvG7Atqi3INF5s=
 github.com/libp2p/go-flow-metrics v0.0.1/go.mod h1:Iv1GH0sG8DtYN3SVJ2eG221wMiNpZxBdp967ls1g+k8=
 github.com/libp2p/go-libp2p-core v0.0.1 h1:HSTZtFIq/W5Ue43Zw+uWZyy2Vl5WtF0zDjKN8/DT/1I=
@@ -96,6 +98,8 @@ github.com/libp2p/go-libp2p-core v0.2.0 h1:ycFtuNwtZBAJSxzaHbyv6NjG3Yj5Nmra1csHa
 github.com/libp2p/go-libp2p-core v0.2.0/go.mod h1:X0eyB0Gy93v0DZtSYbEM7RnMChm9Uv3j7yRXjO77xSI=
 github.com/libp2p/go-libp2p-core v0.2.2 h1:Sv1ggdoMx9c7v7FOFkR7agraHCnAgqYsXrU1ARSRUMs=
 github.com/libp2p/go-libp2p-core v0.2.2/go.mod h1:8fcwTbsG2B+lTgRJ1ICZtiM5GWCWZVoVrLaDRvIRng0=
+github.com/libp2p/go-libp2p-core v0.2.3-0.20190913134417-43e3c9c85923 h1:XqkGF+QVkKC81ZLXSzGorPIup4p0NiGF5FpcihD0CX8=
+github.com/libp2p/go-libp2p-core v0.2.3-0.20190913134417-43e3c9c85923/go.mod h1:1Muyk4HEeyPytWH5XRiczNC1ghbTq70PNn0uEbcLCxY=
 github.com/libp2p/go-libp2p-loggables v0.1.0 h1:h3w8QFfCt2UJl/0/NW4K829HX/0S4KD31PQ7m8UXXO8=
 github.com/libp2p/go-libp2p-loggables v0.1.0/go.mod h1:EyumB2Y6PrYjr55Q3/tiJ/o3xoDasoRYM7nOzEpoa90=
 github.com/libp2p/go-libp2p-mplex v0.2.0/go.mod h1:Ejl9IyjvXJ0T9iqUTE1jpYATQ9NM3g+OtR+EMMODbKo=
@@ -107,6 +111,7 @@ github.com/libp2p/go-libp2p-secio v0.2.0 h1:ywzZBsWEEz2KNTn5RtzauEDq5RFEefPsttXY
 github.com/libp2p/go-libp2p-secio v0.2.0/go.mod h1:2JdZepB8J5V9mBp79BmwsaPQhRPNN2NrnB2lKQcdy6g=
 github.com/libp2p/go-libp2p-testing v0.0.2/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
 github.com/libp2p/go-libp2p-testing v0.0.3/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
+github.com/libp2p/go-libp2p-testing v0.0.4/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
 github.com/libp2p/go-libp2p-testing v0.1.0 h1:WaFRj/t3HdMZGNZqnU2pS7pDRBmMeoDx7/HDNpeyT9U=
 github.com/libp2p/go-libp2p-testing v0.1.0/go.mod h1:xaZWMJrPUM5GlDBxCeGUi7kI4eqnjVyavGroI2nxEM0=
 github.com/libp2p/go-libp2p-transport-upgrader v0.1.1 h1:PZMS9lhjK9VytzMCW3tWHAXtKXmlURSc3ZdvwEcKCzw=
@@ -177,6 +182,7 @@ github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/g
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.5 h1:1wxmCvTXAifAepIMyF39vZinRw5sbqjPs/UIi93+uik=
 github.com/multiformats/go-multihash v0.0.5/go.mod h1:lt/HCbqlQwlPBz7lv0sQCdtfcMtlJvakRUn/0Ual8po=
+github.com/multiformats/go-multihash v0.0.7/go.mod h1:XuKXPp8VHcTygube3OWZC+aZrA+H1IhmjoCDtJc7PXM=
 github.com/multiformats/go-multihash v0.0.8 h1:wrYcW5yxSi3dU07n5jnuS5PrNwyHy0zRHGVoUugWvXg=
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
 github.com/multiformats/go-multistream v0.1.0 h1:UpO6jrsjqs46mqAK3n6wKRYFhugss9ArzbyUzU+4wkQ=

--- a/swarm.go
+++ b/swarm.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/libp2p/go-eventbus"
+	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/metrics"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -91,10 +93,16 @@ type Swarm struct {
 	proc goprocess.Process
 	ctx  context.Context
 	bwc  metrics.Reporter
+
+	eventBus event.Bus
+	emitters struct {
+		evtPeerConnectionStateChange event.Emitter
+		evtStreamStateChange         event.Emitter
+	}
 }
 
 // NewSwarm constructs a Swarm
-func NewSwarm(ctx context.Context, local peer.ID, peers peerstore.Peerstore, bwc metrics.Reporter) *Swarm {
+func NewSwarm(ctx context.Context, local peer.ID, peers peerstore.Peerstore, bwc metrics.Reporter) (*Swarm, error) {
 	s := &Swarm{
 		local:   local,
 		peers:   peers,
@@ -111,8 +119,18 @@ func NewSwarm(ctx context.Context, local peer.ID, peers peerstore.Peerstore, bwc
 	s.limiter = newDialLimiter(s.dialAddr)
 	s.proc = goprocessctx.WithContextAndTeardown(ctx, s.teardown)
 	s.ctx = goprocessctx.OnClosingContext(s.proc)
+	s.eventBus = eventbus.NewBus()
 
-	return s
+	var err error
+	if s.emitters.evtPeerConnectionStateChange, err = s.eventBus.Emitter(&network.EvtPeerConnectionStateChange{}); err != nil {
+		return nil, err
+	}
+
+	if s.emitters.evtStreamStateChange, err = s.eventBus.Emitter(&network.EvtStreamStateChange{}); err != nil {
+		return nil, err
+	}
+
+	return s, err
 }
 
 func (s *Swarm) teardown() error {
@@ -157,7 +175,15 @@ func (s *Swarm) teardown() error {
 	// Wait for everything to finish.
 	s.refs.Wait()
 
+	// close event bus emitters
+	_ = s.emitters.evtStreamStateChange.Close()
+	_ = s.emitters.evtPeerConnectionStateChange.Close()
+
 	return nil
+}
+
+func (s *Swarm) EventBus() event.Bus {
+	return s.eventBus
 }
 
 // AddAddrFilter adds a multiaddr filter to the set of filters the swarm will use to determine which
@@ -232,6 +258,11 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 	s.notifyAll(func(f network.Notifiee) {
 		f.Connected(s, c)
 	})
+
+	// emit connection state change event on the bus
+	s.emitters.evtPeerConnectionStateChange.Emit(
+		network.EvtPeerConnectionStateChange{s, c, network.Connected})
+
 	c.notifyLk.Unlock()
 
 	c.start()
@@ -470,6 +501,7 @@ func (s *Swarm) notifyAll(notify func(network.Notifiee)) {
 }
 
 // Notify signs up Notifiee to receive signals when events happen
+// Deprecated: use swarm.EventBus().Subscribe()
 func (s *Swarm) Notify(f network.Notifiee) {
 	s.notifs.Lock()
 	s.notifs.m[f] = struct{}{}

--- a/swarm_conn.go
+++ b/swarm_conn.go
@@ -76,6 +76,9 @@ func (c *Conn) doClose() {
 			f.Disconnected(c.swarm, c)
 		})
 		c.swarm.refs.Done() // taken in Swarm.addConn
+
+		c.swarm.emitters.evtPeerConnectionStateChange.Emit(
+			network.EvtPeerConnectionStateChange{c.swarm, c, network.NotConnected})
 	}()
 }
 
@@ -206,6 +209,10 @@ func (c *Conn) addStream(ts mux.MuxedStream, dir network.Direction) (*Stream, er
 	c.swarm.notifyAll(func(f network.Notifiee) {
 		f.OpenedStream(c.swarm, s)
 	})
+
+	c.swarm.emitters.evtStreamStateChange.Emit(
+		network.EvtStreamStateChange{c.swarm, s, network.Connected})
+
 	s.notifyLk.Unlock()
 
 	return s, nil

--- a/swarm_event_bus_test.go
+++ b/swarm_event_bus_test.go
@@ -1,0 +1,203 @@
+package swarm_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/event"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	. "github.com/libp2p/go-libp2p-swarm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventBus(t *testing.T) {
+	const swarmSize = 5
+
+	ctx := context.Background()
+	swarms := makeSwarms(ctx, t, swarmSize)
+	defer func() {
+		for _, s := range swarms {
+			s.Close()
+		}
+	}()
+
+	timeout := 5 * time.Second
+
+	// subscribe to event bus for peer connections
+	connSubs := make([]event.Subscription, len(swarms))
+	// subscribe to event bus for stream notifs
+	streamSubs := make([]event.Subscription, len(swarms))
+
+	var err error
+	for i, swarm := range swarms {
+		connSubs[i], err = swarm.EventBus().Subscribe(&network.EvtPeerConnectionStateChange{})
+		require.NoError(t, err)
+		streamSubs[i], err = swarm.EventBus().Subscribe(&network.EvtStreamStateChange{})
+		require.NoError(t, err)
+		defer connSubs[i].Close()
+		defer streamSubs[i].Close()
+	}
+
+	connectSwarms(t, ctx, swarms)
+
+	<-time.After(time.Millisecond)
+	// should've gotten 5 by now.
+
+	// test everyone got the correct connection opened calls
+	for i, s := range swarms {
+		sub := connSubs[i]
+		notifs := make(map[peer.ID][]network.Conn)
+		for j, s2 := range swarms {
+			if i == j {
+				continue
+			}
+
+			// this feels a little sketchy, but its probably okay
+			for len(s.ConnsToPeer(s2.LocalPeer())) != len(notifs[s2.LocalPeer()]) {
+				select {
+				case o := <-sub.Out():
+					evt := o.(network.EvtPeerConnectionStateChange)
+					require.Equal(t, network.Connected, evt.NewState)
+					c := evt.Connection
+					nfp := notifs[c.RemotePeer()]
+					notifs[c.RemotePeer()] = append(nfp, c)
+				case <-time.After(timeout):
+					t.Fatal("timeout")
+				}
+			}
+		}
+
+		for p, cons := range notifs {
+			expect := s.ConnsToPeer(p)
+			if len(expect) != len(cons) {
+				t.Fatal("got different number of connections")
+			}
+
+			for _, c := range cons {
+				var found bool
+				for _, c2 := range expect {
+					if c == c2 {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					t.Fatal("connection not found!")
+				}
+			}
+		}
+	}
+
+	complement := func(c network.Conn, isConn bool) (*Swarm, event.Subscription, *Conn) {
+		var sub event.Subscription
+		for i, s := range swarms {
+			if isConn {
+				sub = connSubs[i]
+			} else {
+				sub = streamSubs[i]
+			}
+			for _, c2 := range s.Conns() {
+				if c.LocalMultiaddr().Equal(c2.RemoteMultiaddr()) &&
+					c2.LocalMultiaddr().Equal(c.RemoteMultiaddr()) {
+
+					return s, sub, c2.(*Conn)
+				}
+			}
+		}
+		t.Fatal("complementary conn not found", c)
+		return nil, nil, nil
+	}
+
+	testOCStream := func(sub event.Subscription, s network.Stream) {
+		var s2 network.Stream
+		select {
+		case o := <-sub.Out():
+			evt := o.(network.EvtStreamStateChange)
+			require.Equal(t, network.Connected, evt.NewState)
+			s2 = evt.Stream
+			t.Log("got notif for opened stream")
+		case <-time.After(timeout):
+			t.Fatal("timeout")
+		}
+		if s != s2 {
+			t.Fatal("got incorrect stream", s.Conn(), s2.Conn())
+		}
+
+		select {
+		case o := <-sub.Out():
+			evt := o.(network.EvtStreamStateChange)
+			require.Equal(t, network.NotConnected, evt.NewState)
+			s2 = evt.Stream
+			t.Log("got notif for closed stream")
+		case <-time.After(timeout):
+			t.Fatal("timeout")
+		}
+		if s != s2 {
+			t.Fatal("got incorrect stream", s.Conn(), s2.Conn())
+		}
+	}
+
+	streams := make(chan network.Stream)
+	for _, s := range swarms {
+		s.SetStreamHandler(func(s network.Stream) {
+			streams <- s
+			s.Reset()
+		})
+	}
+
+	// open a streams in each conn
+	for i, s := range swarms {
+		for _, c := range s.Conns() {
+			_, n2, _ := complement(c, false)
+
+			st1, err := c.NewStream()
+			if err != nil {
+				t.Error(err)
+			} else {
+				st1.Write([]byte("hello"))
+				st1.Reset()
+				testOCStream(streamSubs[i], st1)
+				st2 := <-streams
+				testOCStream(n2, st2)
+			}
+		}
+	}
+
+	// close conns
+	for i, s := range swarms {
+		n := connSubs[i]
+		for _, c := range s.Conns() {
+			_, n2, c2 := complement(c, true)
+			c.Close()
+			c2.Close()
+
+			var c3, c4 network.Conn
+			select {
+			case o := <-n.Out():
+				evt := o.(network.EvtPeerConnectionStateChange)
+				require.Equal(t, network.NotConnected, evt.NewState)
+				c3 = evt.Connection
+			case <-time.After(timeout):
+				t.Fatal("timeout")
+			}
+			if c != c3 {
+				t.Fatal("got incorrect conn", c, c3)
+			}
+
+			select {
+			case o := <-n2.Out():
+				evt := o.(network.EvtPeerConnectionStateChange)
+				require.Equal(t, network.NotConnected, evt.NewState)
+				c4 = evt.Connection
+			case <-time.After(timeout):
+				t.Fatal("timeout")
+			}
+			if c2 != c4 {
+				t.Fatal("got incorrect conn", c, c2)
+			}
+		}
+	}
+}

--- a/swarm_stream.go
+++ b/swarm_stream.go
@@ -137,6 +137,8 @@ func (s *Stream) remove() {
 			f.ClosedStream(s.conn.swarm, s)
 		})
 		s.conn.swarm.refs.Done()
+		s.conn.swarm.emitters.evtStreamStateChange.Emit(
+			network.EvtStreamStateChange{s.conn.swarm, s, network.NotConnected})
 	}()
 }
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -18,7 +18,7 @@ import (
 	yamux "github.com/libp2p/go-libp2p-yamux"
 	msmux "github.com/libp2p/go-stream-muxer-multistream"
 
-	swarm "github.com/libp2p/go-libp2p-swarm"
+	"github.com/libp2p/go-libp2p-swarm"
 )
 
 type config struct {
@@ -66,13 +66,15 @@ func GenSwarm(t *testing.T, ctx context.Context, opts ...Option) *swarm.Swarm {
 	for _, o := range opts {
 		o(t, &cfg)
 	}
-
 	p := tnet.RandPeerNetParamsOrFatal(t)
 
 	ps := pstoremem.NewPeerstore()
 	ps.AddPubKey(p.ID, p.PubKey)
 	ps.AddPrivKey(p.ID, p.PrivKey)
-	s := swarm.NewSwarm(ctx, p.ID, ps, metrics.NewBandwidthCounter())
+	s, err := swarm.NewSwarm(ctx, p.ID, ps, metrics.NewBandwidthCounter())
+	if err != nil {
+		t.Fatalf("failed to create swarm, error is %s", err)
+	}
 	s.Process().AddChild(goprocess.WithTeardown(ps.Close))
 
 	tcpTransport := tcp.NewTCPTransport(GenUpgrader(s))


### PR DESCRIPTION
Please refer to the discussion at:
https://github.com/libp2p/go-libp2p-peerstore/issues/93#issuecomment-531056831

### **TODO**
- [ ] Get  the corresponding [libp2p-core PR](https://github.com/libp2p/go-libp2p-core/pull/57) merged.  
- [ ] Release libp2p-core to get new version.
- [ ] Update go.mod with the new libp2p-core version.