### PR TITLE
Go mod version is old.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/libp2p/go-libp2p-swarm
 
+go 1.13
+
 require (
 	github.com/ipfs/go-log v0.0.1
 	github.com/jbenet/goprocess v0.1.3


### PR DESCRIPTION
```gomod
module xxx

go 1.13

require xxx
```

Not `go xxx` is 1.11. very old.