### PR TITLE
improve dial errors

### DIFF
--- a/dial_error.go
+++ b/dial_error.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -18,6 +19,10 @@ type DialError struct {
 	DialErrors []TransportError
 	Cause      error
 	Skipped    int
+}
+
+func (e *DialError) Timeout() bool {
+	return os.IsTimeout(e.Cause)
 }
 
 func (e *DialError) recordErr(addr ma.Multiaddr, err error) {
@@ -48,11 +53,7 @@ func (e *DialError) Error() string {
 
 // Unwrap implements https://godoc.org/golang.org/x/xerrors#Wrapper.
 func (e *DialError) Unwrap() error {
-	// If we have a context error, that's the "ultimate" error.
-	if e.Cause != nil {
-		return e.Cause
-	}
-	return nil
+	return e.Cause
 }
 
 var _ error = (*DialError)(nil)

--- a/swarm.go
+++ b/swarm.go
@@ -40,6 +40,9 @@ var ErrSwarmClosed = errors.New("swarm closed")
 // transport is misbehaving.
 var ErrAddrFiltered = errors.New("address filtered")
 
+// ErrDialTimeout is returned when one a dial times out due to the global timeout
+var ErrDialTimeout = errors.New("dial timed out")
+
 // Swarm is a connection muxer, allowing connections to other peers to
 // be opened and closed, while still using the same Chan for all
 // communication. The Chan sends/receives Messages, which note the


### PR DESCRIPTION
1. Always return the caller's context error if relevant.
2. Don't return "context canceled" when we're just shutting down.
3. Don't claim that the context deadline has been exceeded when the dial timeout is canceled.
4. Don't return a "context canceled" error when we're _internally_ canceling the dial.