### PR TITLE
don't expire backoffs until 2x backoff period

### DIFF
--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -196,7 +196,11 @@ func (db *DialBackoff) cleanup() {
 	for p, e := range db.entries {
 		good := false
 		for _, backoff := range e {
-			if now.Before(backoff.until) {
+			backoffTime := BackoffBase + BackoffCoef*time.Duration(backoff.tries*backoff.tries)
+			if backoffTime > BackoffMax {
+				backoffTime = BackoffMax
+			}
+			if now.Before(backoff.until.Add(backoffTime)) {
 				good = true
 				break
 			}


### PR DESCRIPTION
with the background cleanup process introduced in #191 backoffs would get cleaned up as soon as they expire. They should stick around after to be extended rather than immediately restarting in that case. this keeps them alive a bit longer after expiry.