### PR TITLE
implement connection gating support: intercept peer, address dials, upgraded conns

### DIFF
--- a/addrs.go
+++ b/addrs.go
@@ -1,12 +1,12 @@
 package swarm
 
 import (
-	mafilter "github.com/libp2p/go-maddr-filter"
+	ma "github.com/multiformats/go-multiaddr"
 	mamask "github.com/whyrusleeping/multiaddr-filter"
 )
 
 // http://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
-var lowTimeoutFilters = mafilter.NewFilters()
+var lowTimeoutFilters = ma.NewFilters()
 
 func init() {
 	for _, p := range []string{

--- a/go.mod
+++ b/go.mod
@@ -5,17 +5,16 @@ require (
 	github.com/jbenet/goprocess v0.1.4
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-conn-security-multistream v0.2.0
-	github.com/libp2p/go-libp2p-core v0.5.4-0.20200513121538-909c77480f73
+	github.com/libp2p/go-libp2p-core v0.5.5
 	github.com/libp2p/go-libp2p-loggables v0.1.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.3
 	github.com/libp2p/go-libp2p-secio v0.2.2
 	github.com/libp2p/go-libp2p-testing v0.1.1
 	github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513191341-03eaee6978e2
 	github.com/libp2p/go-libp2p-yamux v0.2.7
-	github.com/libp2p/go-maddr-filter v0.0.5
 	github.com/libp2p/go-stream-muxer-multistream v0.3.0
 	github.com/libp2p/go-tcp-transport v0.2.0
-	github.com/multiformats/go-multiaddr v0.2.1
+	github.com/multiformats/go-multiaddr v0.2.2
 	github.com/multiformats/go-multiaddr-fmt v0.1.0
 	github.com/multiformats/go-multiaddr-net v0.1.5
 	github.com/stretchr/testify v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/libp2p/go-libp2p-peerstore v0.2.3
 	github.com/libp2p/go-libp2p-secio v0.2.2
 	github.com/libp2p/go-libp2p-testing v0.1.1
-	github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513191341-03eaee6978e2
+	github.com/libp2p/go-libp2p-transport-upgrader v0.3.0
 	github.com/libp2p/go-libp2p-yamux v0.2.7
 	github.com/libp2p/go-stream-muxer-multistream v0.3.0
 	github.com/libp2p/go-tcp-transport v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/libp2p/go-conn-security-multistream v0.2.0
 	github.com/libp2p/go-libp2p-core v0.5.5
 	github.com/libp2p/go-libp2p-loggables v0.1.0
-	github.com/libp2p/go-libp2p-peerstore v0.2.3
+	github.com/libp2p/go-libp2p-peerstore v0.2.4
 	github.com/libp2p/go-libp2p-secio v0.2.2
 	github.com/libp2p/go-libp2p-testing v0.1.1
 	github.com/libp2p/go-libp2p-transport-upgrader v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,19 +5,20 @@ require (
 	github.com/jbenet/goprocess v0.1.4
 	github.com/libp2p/go-addr-util v0.0.2
 	github.com/libp2p/go-conn-security-multistream v0.2.0
-	github.com/libp2p/go-libp2p-core v0.5.2
+	github.com/libp2p/go-libp2p-core v0.5.4-0.20200513121538-909c77480f73
 	github.com/libp2p/go-libp2p-loggables v0.1.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.3
 	github.com/libp2p/go-libp2p-secio v0.2.2
 	github.com/libp2p/go-libp2p-testing v0.1.1
-	github.com/libp2p/go-libp2p-transport-upgrader v0.2.0
+	github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513191341-03eaee6978e2
 	github.com/libp2p/go-libp2p-yamux v0.2.7
 	github.com/libp2p/go-maddr-filter v0.0.5
 	github.com/libp2p/go-stream-muxer-multistream v0.3.0
 	github.com/libp2p/go-tcp-transport v0.2.0
 	github.com/multiformats/go-multiaddr v0.2.1
 	github.com/multiformats/go-multiaddr-fmt v0.1.0
-	github.com/multiformats/go-multiaddr-net v0.1.4
+	github.com/multiformats/go-multiaddr-net v0.1.5
+	github.com/stretchr/testify v1.4.0
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -139,12 +139,10 @@ github.com/libp2p/go-libp2p-core v0.5.0 h1:FBQ1fpq2Fo/ClyjojVJ5AKXlKhvNc/B6U0O+7
 github.com/libp2p/go-libp2p-core v0.5.0/go.mod h1:49XGI+kc38oGVwqSBhDEwytaAxgZasHhFfQKibzTls0=
 github.com/libp2p/go-libp2p-core v0.5.1 h1:6Cu7WljPQtGY2krBlMoD8L/zH3tMUsCbqNFH7cZwCoI=
 github.com/libp2p/go-libp2p-core v0.5.1/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
-github.com/libp2p/go-libp2p-core v0.5.2 h1:hevsCcdLiazurKBoeNn64aPYTVOPdY4phaEGeLtHOAs=
-github.com/libp2p/go-libp2p-core v0.5.2/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
-github.com/libp2p/go-libp2p-core v0.5.3 h1:b9W3w7AZR2n/YJhG8d0qPFGhGhCWKIvPuJgp4hhc4MM=
-github.com/libp2p/go-libp2p-core v0.5.3/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
 github.com/libp2p/go-libp2p-core v0.5.4-0.20200513121538-909c77480f73 h1:T/QzsIGsBVYhp53OoJsYFqaOcTQ7BT1VJ4Zeltd3Fsg=
 github.com/libp2p/go-libp2p-core v0.5.4-0.20200513121538-909c77480f73/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
+github.com/libp2p/go-libp2p-core v0.5.5 h1:/yiFUZDoBWqvpWeHHJ1iA8SOs5obT1/+UdNfckwD57M=
+github.com/libp2p/go-libp2p-core v0.5.5/go.mod h1:vj3awlOr9+GMZJFH9s4mpt9RHHgGqeHCopzbYKZdRjM=
 github.com/libp2p/go-libp2p-loggables v0.1.0 h1:h3w8QFfCt2UJl/0/NW4K829HX/0S4KD31PQ7m8UXXO8=
 github.com/libp2p/go-libp2p-loggables v0.1.0/go.mod h1:EyumB2Y6PrYjr55Q3/tiJ/o3xoDasoRYM7nOzEpoa90=
 github.com/libp2p/go-libp2p-mplex v0.2.1 h1:E1xaJBQnbSiTHGI1gaBKmKhu1TUKkErKJnE8iGvirYI=
@@ -162,8 +160,6 @@ github.com/libp2p/go-libp2p-testing v0.1.1 h1:U03z3HnGI7Ni8Xx6ONVZvUFOAzWYmolWf5
 github.com/libp2p/go-libp2p-testing v0.1.1/go.mod h1:xaZWMJrPUM5GlDBxCeGUi7kI4eqnjVyavGroI2nxEM0=
 github.com/libp2p/go-libp2p-transport-upgrader v0.2.0 h1:5EhPgQhXZNyfL22ERZTUoVp9UVVbNowWNVtELQaKCHk=
 github.com/libp2p/go-libp2p-transport-upgrader v0.2.0/go.mod h1:mQcrHj4asu6ArfSoMuyojOdjx73Q47cYD7s5+gZOlns=
-github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513182223-1a7cd59830fe h1:Q4d/4pkrdonWw/zigLliA1JPxQOsmGmyObUpP9/GU0c=
-github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513182223-1a7cd59830fe/go.mod h1:YPA5DpaWLrUZPdqT18Y2O29DPqU0gaUaIvcAbCELrp4=
 github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513191341-03eaee6978e2 h1:buWeQMj+CK6MEwyNxwPbViSDhPO0SHD3ZKQN7HCZDN0=
 github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513191341-03eaee6978e2/go.mod h1:+oEP3yVBU4dP/a8od+lUL3J+8BGP/c89GcSDeZP4gQs=
 github.com/libp2p/go-libp2p-yamux v0.2.7 h1:vzKu0NVtxvEIDGCv6mjKRcK0gipSgaXmJZ6jFv0d/dk=
@@ -180,6 +176,8 @@ github.com/libp2p/go-netroute v0.1.2 h1:UHhB35chwgvcRI392znJA3RCBtZ3MpE3ahNCN5MR
 github.com/libp2p/go-netroute v0.1.2/go.mod h1:jZLDV+1PE8y5XxBySEBgbuVAXbhtuHSdmLPL2n9MKbk=
 github.com/libp2p/go-openssl v0.0.4 h1:d27YZvLoTyMhIN4njrkr8zMDOM4lfpHIp6A+TK9fovg=
 github.com/libp2p/go-openssl v0.0.4/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
+github.com/libp2p/go-openssl v0.0.5 h1:pQkejVhF0xp08D4CQUcw8t+BFJeXowja6RVcb5p++EA=
+github.com/libp2p/go-openssl v0.0.5/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/libp2p/go-reuseport v0.0.1 h1:7PhkfH73VXfPJYKQ6JwS5I/eVcoyYi9IMNGc6FWpFLw=
 github.com/libp2p/go-reuseport v0.0.1/go.mod h1:jn6RmB1ufnQwl0Q1f+YxAj8isJgDCQzaaxIFYDhcYEA=
 github.com/libp2p/go-reuseport-transport v0.0.3 h1:zzOeXnTooCkRvoH+bSXEfXhn76+LAiwoneM0gnXjF2M=
@@ -232,6 +230,8 @@ github.com/multiformats/go-multiaddr v0.2.0 h1:lR52sFwcTCuQb6bTfnXF6zA2XfyYvyd+5
 github.com/multiformats/go-multiaddr v0.2.0/go.mod h1:0nO36NvPpyV4QzvTLi/lafl2y95ncPj0vFwVF6k6wJ4=
 github.com/multiformats/go-multiaddr v0.2.1 h1:SgG/cw5vqyB5QQe5FPe2TqggU9WtrA9X4nZw7LlVqOI=
 github.com/multiformats/go-multiaddr v0.2.1/go.mod h1:s/Apk6IyxfvMjDafnhJgJ3/46z7tZ04iMk5wP4QMGGE=
+github.com/multiformats/go-multiaddr v0.2.2 h1:XZLDTszBIJe6m0zF6ITBrEcZR73OPUhCBBS9rYAuUzI=
+github.com/multiformats/go-multiaddr v0.2.2/go.mod h1:NtfXiOtHvghW9KojvtySjH5y0u0xW5UouOmQQrn6a3Y=
 github.com/multiformats/go-multiaddr-fmt v0.1.0 h1:WLEFClPycPkp4fnIzoFoV9FVd49/eQsuaL3/CWe167E=
 github.com/multiformats/go-multiaddr-fmt v0.1.0/go.mod h1:hGtDIW4PU4BqJ50gW2quDuPVjyWNZxToGUh/HwTZYJo=
 github.com/multiformats/go-multiaddr-net v0.1.2 h1:P7zcBH9FRETdPkDrylcXVjQLQ2t1JQtNItZULWNWgeg=

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,7 @@ github.com/libp2p/go-libp2p-core v0.5.0 h1:FBQ1fpq2Fo/ClyjojVJ5AKXlKhvNc/B6U0O+7
 github.com/libp2p/go-libp2p-core v0.5.0/go.mod h1:49XGI+kc38oGVwqSBhDEwytaAxgZasHhFfQKibzTls0=
 github.com/libp2p/go-libp2p-core v0.5.1 h1:6Cu7WljPQtGY2krBlMoD8L/zH3tMUsCbqNFH7cZwCoI=
 github.com/libp2p/go-libp2p-core v0.5.1/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
+github.com/libp2p/go-libp2p-core v0.5.4/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
 github.com/libp2p/go-libp2p-core v0.5.5 h1:/yiFUZDoBWqvpWeHHJ1iA8SOs5obT1/+UdNfckwD57M=
 github.com/libp2p/go-libp2p-core v0.5.5/go.mod h1:vj3awlOr9+GMZJFH9s4mpt9RHHgGqeHCopzbYKZdRjM=
 github.com/libp2p/go-libp2p-loggables v0.1.0 h1:h3w8QFfCt2UJl/0/NW4K829HX/0S4KD31PQ7m8UXXO8=
@@ -147,8 +148,8 @@ github.com/libp2p/go-libp2p-mplex v0.2.1 h1:E1xaJBQnbSiTHGI1gaBKmKhu1TUKkErKJnE8
 github.com/libp2p/go-libp2p-mplex v0.2.1/go.mod h1:SC99Rxs8Vuzrf/6WhmH41kNn13TiYdAWNYHrwImKLnE=
 github.com/libp2p/go-libp2p-mplex v0.2.3 h1:2zijwaJvpdesST2MXpI5w9wWFRgYtMcpRX7rrw0jmOo=
 github.com/libp2p/go-libp2p-mplex v0.2.3/go.mod h1:CK3p2+9qH9x+7ER/gWWDYJ3QW5ZxWDkm+dVvjfuG3ek=
-github.com/libp2p/go-libp2p-peerstore v0.2.3 h1:MofRq2l3c15vQpEygTetV+zRRrncz+ktiXW7H2EKoEQ=
-github.com/libp2p/go-libp2p-peerstore v0.2.3/go.mod h1:K8ljLdFn590GMttg/luh4caB/3g0vKuY01psze0upRw=
+github.com/libp2p/go-libp2p-peerstore v0.2.4 h1:jU9S4jYN30kdzTpDAR7SlHUD+meDUjTODh4waLWF1ws=
+github.com/libp2p/go-libp2p-peerstore v0.2.4/go.mod h1:ss/TWTgHZTMpsU/oKVVPQCGuDHItOpf2W8RxAi50P2s=
 github.com/libp2p/go-libp2p-pnet v0.2.0 h1:J6htxttBipJujEjz1y0a5+eYoiPcFHhSYHH6na5f0/k=
 github.com/libp2p/go-libp2p-pnet v0.2.0/go.mod h1:Qqvq6JH/oMZGwqs3N1Fqhv8NVhrdYcO0BW4wssv21LA=
 github.com/libp2p/go-libp2p-secio v0.2.2 h1:rLLPvShPQAcY6eNurKNZq3eZjPWfU9kXF2eI9jIYdrg=

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/ipfs/go-log/v2 v2.0.5/go.mod h1:eZs4Xt4ZUJQFM3DlanGhy7TkwwawCZcSByscw
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
 github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2 h1:vhC1OXXiT9R2pczegwz6moDvuRpggaroAXhPIseh57A=
 github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2/go.mod h1:8GXXJV31xl8whumTzdZsTt3RnUIiPqzkyf7mxToRCMs=
+github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=
+github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=
 github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8/go.mod h1:Ly/wlsjFq/qrU3Rar62tu1gASgGw6chQbSh/XgIIXCY=
 github.com/jbenet/goprocess v0.1.3 h1:YKyIEECS/XvcfHtBzxtjBBbWK+MbvA6dG8ASiqwvr10=
 github.com/jbenet/goprocess v0.1.3/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
@@ -139,6 +141,10 @@ github.com/libp2p/go-libp2p-core v0.5.1 h1:6Cu7WljPQtGY2krBlMoD8L/zH3tMUsCbqNFH7
 github.com/libp2p/go-libp2p-core v0.5.1/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
 github.com/libp2p/go-libp2p-core v0.5.2 h1:hevsCcdLiazurKBoeNn64aPYTVOPdY4phaEGeLtHOAs=
 github.com/libp2p/go-libp2p-core v0.5.2/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
+github.com/libp2p/go-libp2p-core v0.5.3 h1:b9W3w7AZR2n/YJhG8d0qPFGhGhCWKIvPuJgp4hhc4MM=
+github.com/libp2p/go-libp2p-core v0.5.3/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
+github.com/libp2p/go-libp2p-core v0.5.4-0.20200513121538-909c77480f73 h1:T/QzsIGsBVYhp53OoJsYFqaOcTQ7BT1VJ4Zeltd3Fsg=
+github.com/libp2p/go-libp2p-core v0.5.4-0.20200513121538-909c77480f73/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
 github.com/libp2p/go-libp2p-loggables v0.1.0 h1:h3w8QFfCt2UJl/0/NW4K829HX/0S4KD31PQ7m8UXXO8=
 github.com/libp2p/go-libp2p-loggables v0.1.0/go.mod h1:EyumB2Y6PrYjr55Q3/tiJ/o3xoDasoRYM7nOzEpoa90=
 github.com/libp2p/go-libp2p-mplex v0.2.1 h1:E1xaJBQnbSiTHGI1gaBKmKhu1TUKkErKJnE8iGvirYI=
@@ -156,6 +162,10 @@ github.com/libp2p/go-libp2p-testing v0.1.1 h1:U03z3HnGI7Ni8Xx6ONVZvUFOAzWYmolWf5
 github.com/libp2p/go-libp2p-testing v0.1.1/go.mod h1:xaZWMJrPUM5GlDBxCeGUi7kI4eqnjVyavGroI2nxEM0=
 github.com/libp2p/go-libp2p-transport-upgrader v0.2.0 h1:5EhPgQhXZNyfL22ERZTUoVp9UVVbNowWNVtELQaKCHk=
 github.com/libp2p/go-libp2p-transport-upgrader v0.2.0/go.mod h1:mQcrHj4asu6ArfSoMuyojOdjx73Q47cYD7s5+gZOlns=
+github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513182223-1a7cd59830fe h1:Q4d/4pkrdonWw/zigLliA1JPxQOsmGmyObUpP9/GU0c=
+github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513182223-1a7cd59830fe/go.mod h1:YPA5DpaWLrUZPdqT18Y2O29DPqU0gaUaIvcAbCELrp4=
+github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513191341-03eaee6978e2 h1:buWeQMj+CK6MEwyNxwPbViSDhPO0SHD3ZKQN7HCZDN0=
+github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513191341-03eaee6978e2/go.mod h1:+oEP3yVBU4dP/a8od+lUL3J+8BGP/c89GcSDeZP4gQs=
 github.com/libp2p/go-libp2p-yamux v0.2.7 h1:vzKu0NVtxvEIDGCv6mjKRcK0gipSgaXmJZ6jFv0d/dk=
 github.com/libp2p/go-libp2p-yamux v0.2.7/go.mod h1:X28ENrBMU/nm4I3Nx4sZ4dgjZ6VhLEn0XhIoZ5viCwU=
 github.com/libp2p/go-maddr-filter v0.0.5 h1:CW3AgbMO6vUvT4kf87y4N+0P8KUl2aqLYhrGyDUbLSg=
@@ -230,6 +240,8 @@ github.com/multiformats/go-multiaddr-net v0.1.3 h1:q/IYAvoPKuRzGeERn3uacWgm0LIWk
 github.com/multiformats/go-multiaddr-net v0.1.3/go.mod h1:ilNnaM9HbmVFqsb/qcNysjCu4PVONlrBZpHIrw/qQuA=
 github.com/multiformats/go-multiaddr-net v0.1.4 h1:g6gwydsfADqFvrHoMkS0n9Ok9CG6F7ytOH/bJDkhIOY=
 github.com/multiformats/go-multiaddr-net v0.1.4/go.mod h1:ilNnaM9HbmVFqsb/qcNysjCu4PVONlrBZpHIrw/qQuA=
+github.com/multiformats/go-multiaddr-net v0.1.5 h1:QoRKvu0xHN1FCFJcMQLbG/yQE2z441L5urvG3+qyz7g=
+github.com/multiformats/go-multiaddr-net v0.1.5/go.mod h1:ilNnaM9HbmVFqsb/qcNysjCu4PVONlrBZpHIrw/qQuA=
 github.com/multiformats/go-multibase v0.0.1 h1:PN9/v21eLywrFWdFNsFKaU04kLJzuYzmrJR+ubhT9qA=
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,6 @@ github.com/libp2p/go-libp2p-core v0.5.0 h1:FBQ1fpq2Fo/ClyjojVJ5AKXlKhvNc/B6U0O+7
 github.com/libp2p/go-libp2p-core v0.5.0/go.mod h1:49XGI+kc38oGVwqSBhDEwytaAxgZasHhFfQKibzTls0=
 github.com/libp2p/go-libp2p-core v0.5.1 h1:6Cu7WljPQtGY2krBlMoD8L/zH3tMUsCbqNFH7cZwCoI=
 github.com/libp2p/go-libp2p-core v0.5.1/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
-github.com/libp2p/go-libp2p-core v0.5.4-0.20200513121538-909c77480f73 h1:T/QzsIGsBVYhp53OoJsYFqaOcTQ7BT1VJ4Zeltd3Fsg=
-github.com/libp2p/go-libp2p-core v0.5.4-0.20200513121538-909c77480f73/go.mod h1:uN7L2D4EvPCvzSH5SrhR72UWbnSGpt5/a35Sm4upn4Y=
 github.com/libp2p/go-libp2p-core v0.5.5 h1:/yiFUZDoBWqvpWeHHJ1iA8SOs5obT1/+UdNfckwD57M=
 github.com/libp2p/go-libp2p-core v0.5.5/go.mod h1:vj3awlOr9+GMZJFH9s4mpt9RHHgGqeHCopzbYKZdRjM=
 github.com/libp2p/go-libp2p-loggables v0.1.0 h1:h3w8QFfCt2UJl/0/NW4K829HX/0S4KD31PQ7m8UXXO8=
@@ -160,8 +158,8 @@ github.com/libp2p/go-libp2p-testing v0.1.1 h1:U03z3HnGI7Ni8Xx6ONVZvUFOAzWYmolWf5
 github.com/libp2p/go-libp2p-testing v0.1.1/go.mod h1:xaZWMJrPUM5GlDBxCeGUi7kI4eqnjVyavGroI2nxEM0=
 github.com/libp2p/go-libp2p-transport-upgrader v0.2.0 h1:5EhPgQhXZNyfL22ERZTUoVp9UVVbNowWNVtELQaKCHk=
 github.com/libp2p/go-libp2p-transport-upgrader v0.2.0/go.mod h1:mQcrHj4asu6ArfSoMuyojOdjx73Q47cYD7s5+gZOlns=
-github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513191341-03eaee6978e2 h1:buWeQMj+CK6MEwyNxwPbViSDhPO0SHD3ZKQN7HCZDN0=
-github.com/libp2p/go-libp2p-transport-upgrader v0.2.1-0.20200513191341-03eaee6978e2/go.mod h1:+oEP3yVBU4dP/a8od+lUL3J+8BGP/c89GcSDeZP4gQs=
+github.com/libp2p/go-libp2p-transport-upgrader v0.3.0 h1:q3ULhsknEQ34eVDhv4YwKS8iet69ffs9+Fir6a7weN4=
+github.com/libp2p/go-libp2p-transport-upgrader v0.3.0/go.mod h1:i+SKzbRnvXdVbU3D1dwydnTmKRPXiAR/fyvi1dXuL4o=
 github.com/libp2p/go-libp2p-yamux v0.2.7 h1:vzKu0NVtxvEIDGCv6mjKRcK0gipSgaXmJZ6jFv0d/dk=
 github.com/libp2p/go-libp2p-yamux v0.2.7/go.mod h1:X28ENrBMU/nm4I3Nx4sZ4dgjZ6VhLEn0XhIoZ5viCwU=
 github.com/libp2p/go-maddr-filter v0.0.5 h1:CW3AgbMO6vUvT4kf87y4N+0P8KUl2aqLYhrGyDUbLSg=

--- a/swarm.go
+++ b/swarm.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/libp2p/go-libp2p-core/connmgr"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/libp2p/go-libp2p-core/connmgr"
 	"github.com/libp2p/go-libp2p-core/metrics"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"

--- a/swarm.go
+++ b/swarm.go
@@ -181,7 +181,7 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 				rejectConnection = true
 			}
 		case network.DirOutbound:
-			if !s.ConnGater.InterceptDial(tc.RemoteMultiaddr()) || !s.ConnGater.InterceptPeerDial(p) {
+			if !s.ConnGater.InterceptPeerAddrDial(p, tc.RemoteMultiaddr()) || !s.ConnGater.InterceptPeerDial(p) {
 				rejectConnection = true
 			}
 		}

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -221,7 +221,7 @@ func (db *DialBackoff) cleanup() {
 // This allows us to use various transport protocols, do NAT traversal/relay,
 // etc. to achieve connection.
 func (s *Swarm) DialPeer(ctx context.Context, p peer.ID) (network.Conn, error) {
-	if s.ConnGater != nil && !s.ConnGater.InterceptPeerDial(p) {
+	if s.gater != nil && !s.gater.InterceptPeerDial(p) {
 		log.Debugf("gater disallowed outbound connection to peer %s", p.Pretty())
 		return nil, &DialError{Peer: p, Cause: ErrConnectionAttemptGated}
 	}
@@ -418,7 +418,7 @@ func (s *Swarm) filterKnownUndialables(p peer.ID, addrs []ma.Multiaddr) []ma.Mul
 		// TODO: Consider allowing link-local addresses
 		addrutil.AddrOverNonLocalIP,
 		func(addr ma.Multiaddr) bool {
-			return s.ConnGater == nil || s.ConnGater.InterceptAddrDial(p, addr)
+			return s.gater == nil || s.gater.InterceptAddrDial(p, addr)
 		},
 	)
 }

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -51,8 +51,9 @@ var (
 	// can't use any of them.
 	ErrNoGoodAddresses = errors.New("no good addresses")
 
-	// ErrConnectionAttemptGated is returned when the gater prevents us from forming a connection with a peer.
-	ErrConnectionAttemptGated = errors.New("gater prevented connection to peer")
+	// ErrGaterDisallowedConnection is returned when the gater prevents us from
+	// forming a connection with a peer.
+	ErrGaterDisallowedConnection = errors.New("gater disallows connection to peer")
 )
 
 // DialAttempts governs how many times a goroutine will try to dial a given peer.
@@ -223,7 +224,7 @@ func (db *DialBackoff) cleanup() {
 func (s *Swarm) DialPeer(ctx context.Context, p peer.ID) (network.Conn, error) {
 	if s.gater != nil && !s.gater.InterceptPeerDial(p) {
 		log.Debugf("gater disallowed outbound connection to peer %s", p.Pretty())
-		return nil, &DialError{Peer: p, Cause: ErrConnectionAttemptGated}
+		return nil, &DialError{Peer: p, Cause: ErrGaterDisallowedConnection}
 	}
 
 	return s.dialPeer(ctx, p)

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -348,7 +348,7 @@ func (s *Swarm) dial(ctx context.Context, p peer.ID) (*Conn, error) {
 	if len(peerAddrs) == 0 {
 		return nil, &DialError{Peer: p, Cause: ErrNoAddresses}
 	}
-	goodAddrs := s.filterKnownUndialables(peerAddrs)
+	goodAddrs := s.filterKnownUndialables(p, peerAddrs)
 	if len(goodAddrs) == 0 {
 		return nil, &DialError{Peer: p, Cause: ErrNoGoodAddresses}
 	}
@@ -402,7 +402,7 @@ func (s *Swarm) dial(ctx context.Context, p peer.ID) (*Conn, error) {
 // IPv6 link-local addresses, addresses without a dial-capable transport,
 // and addresses that we know to be our own.
 // This is an optimization to avoid wasting time on dials that we know are going to fail.
-func (s *Swarm) filterKnownUndialables(addrs []ma.Multiaddr) []ma.Multiaddr {
+func (s *Swarm) filterKnownUndialables(p peer.ID, addrs []ma.Multiaddr) []ma.Multiaddr {
 	lisAddrs, _ := s.InterfaceListenAddresses()
 	var ourAddrs []ma.Multiaddr
 	for _, addr := range lisAddrs {
@@ -419,7 +419,7 @@ func (s *Swarm) filterKnownUndialables(addrs []ma.Multiaddr) []ma.Multiaddr {
 		// TODO: Consider allowing link-local addresses
 		addrutil.AddrOverNonLocalIP,
 		func(addr ma.Multiaddr) bool {
-			return s.ConnGater == nil || s.ConnGater.InterceptDial(addr)
+			return s.ConnGater == nil || s.ConnGater.InterceptPeerAddrDial(p, addr)
 		},
 	)
 }

--- a/swarm_listen.go
+++ b/swarm_listen.go
@@ -89,7 +89,6 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 				}
 				return
 			}
-
 			log.Debugf("swarm listener accepted connection: %s", c)
 			s.refs.Add(1)
 			go func() {

--- a/swarm_listen.go
+++ b/swarm_listen.go
@@ -89,6 +89,7 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 				}
 				return
 			}
+
 			log.Debugf("swarm listener accepted connection: %s", c)
 			s.refs.Add(1)
 			go func() {

--- a/swarm_listen.go
+++ b/swarm_listen.go
@@ -90,15 +90,6 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 				return
 			}
 
-			// should we get the incoming connection ?
-			if s.denyConn(c, network.DirInbound) {
-				log.Debugf("swarm listener rejected incoming connection:%s because of gating, closing connection", c)
-				if err := c.Close(); err != nil {
-					log.Debugf("error while closing gated connection,err=%s", err)
-				}
-				continue
-			}
-
 			log.Debugf("swarm listener accepted connection: %s", c)
 			s.refs.Add(1)
 			go func() {

--- a/swarm_listen.go
+++ b/swarm_listen.go
@@ -89,6 +89,16 @@ func (s *Swarm) AddListenAddr(a ma.Multiaddr) error {
 				}
 				return
 			}
+
+			// should we get the incoming connection ?
+			if s.denyConn(c, network.DirInbound) {
+				log.Debugf("swarm listener rejected incoming connection:%s because of gating, closing connection", c)
+				if err := c.Close(); err != nil {
+					log.Debugf("error while closing gated connection,err=%s", err)
+				}
+				continue
+			}
+
 			log.Debugf("swarm listener accepted connection: %s", c)
 			s.refs.Add(1)
 			go func() {

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -4,21 +4,21 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"sync"
 	"testing"
 	"time"
 
-	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
 
-	ma "github.com/multiformats/go-multiaddr"
-
 	. "github.com/libp2p/go-libp2p-swarm"
 	. "github.com/libp2p/go-libp2p-swarm/testing"
+
+	logging "github.com/ipfs/go-log"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
 )
 
 var log = logging.Logger("swarm_test")

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -370,11 +370,13 @@ func TestConnectionGating(t *testing.T) {
 		sw1.Peerstore().AddAddr(p2, sw2.ListenAddresses()[0], peerstore.PermanentAddrTTL)
 		// 1 -> 2
 		_, err := sw1.DialPeer(ctx, p2)
-		// give time for the swarm data structures to be updated
-		time.Sleep(100 * time.Millisecond)
+
 		require.Equal(t, tc.isP1OutboundErr, err != nil, n)
 		require.Equal(t, tc.p1ConnectednessToP2, sw1.Connectedness(p2), n)
-		require.Equal(t, tc.p2ConnectednessToP1, sw2.Connectedness(p1), n)
+
+		require.Eventually(t, func() bool {
+			return tc.p2ConnectednessToP1 == sw2.Connectedness(p1)
+		}, 2*time.Second, 100*time.Millisecond, n)
 	}
 }
 

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -4,16 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/libp2p/go-libp2p-core/control"
-	"github.com/libp2p/go-libp2p-core/transport"
 	"io"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p-core/control"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
+	"github.com/libp2p/go-libp2p-core/transport"
 
 	. "github.com/libp2p/go-libp2p-swarm"
 	. "github.com/libp2p/go-libp2p-swarm/testing"
@@ -375,65 +375,6 @@ func TestConnectionGating(t *testing.T) {
 		require.Equal(t, tc.p2ConnectednessToP1, sw2.Connectedness(p1), n)
 	}
 }
-
-/*func TestPeerIdBlocking(t *testing.T) {
-	// peer1 is not able to connect to peer2 because it gates outbound connections
-	// but peer2 is able to connect to peer1
-	ctx := context.Background()
-	swarms := makeSwarms(ctx, t, 2)
-	swarms[0].Peerstore().AddAddr(swarms[1].LocalPeer(), swarms[1].ListenAddresses()[0], peerstore.PermanentAddrTTL)
-	swarms[1].Peerstore().AddAddr(swarms[0].LocalPeer(), swarms[0].ListenAddresses()[0], peerstore.PermanentAddrTTL)
-
-	gaterForPeer0 := &mockGater{dir: network.DirOutbound, p: swarms[1].LocalPeer()}
-	swarms[0].ConnGater = gaterForPeer0
-
-	c, err := swarms[0].DialPeer(ctx, swarms[1].LocalPeer())
-	require.Nil(t, c)
-	require.Error(t, err)
-	require.Equal(t, network.NotConnected, swarms[0].Connectedness(swarms[1].LocalPeer()))
-
-	c, err = swarms[1].DialPeer(ctx, swarms[0].LocalPeer())
-	require.NotNil(t, c)
-	require.NoError(t, err)
-	require.Equal(t, network.Connected, swarms[1].Connectedness(swarms[0].LocalPeer()))
-
-	// peer2 is not able to connect to peer1 because peer1 gates inbound connections
-	swarms = makeSwarms(ctx, t, 2)
-	swarms[0].Peerstore().AddAddr(swarms[1].LocalPeer(), swarms[1].ListenAddresses()[0], peerstore.PermanentAddrTTL)
-	swarms[1].Peerstore().AddAddr(swarms[0].LocalPeer(), swarms[0].ListenAddresses()[0], peerstore.PermanentAddrTTL)
-
-	swarms[0].ConnGater = &mockGater{dir: network.DirInbound, p: swarms[1].LocalPeer()}
-	c, err = swarms[1].DialPeer(ctx, swarms[0].LocalPeer())
-	// connection is established, but later closed by the other peer, so we should not see connectedness
-	require.True(t, swarms[0].Connectedness(swarms[1].LocalPeer()) == network.NotConnected)
-}
-
-func TestAddrBlocking(t *testing.T) {
-	ctx := context.Background()
-
-	swarms := makeSwarms(ctx, t, 2)
-
-	swarms[0].SetConnHandler(func(conn network.Conn) {
-		t.Errorf("no connections should happen! -- %s", conn)
-	})
-
-	gaterForPeer0 := &mockGater{addrs: swarms[1].ListenAddresses()}
-	gaterForPeer1 := &mockGater{addrs: swarms[0].ListenAddresses()}
-	swarms[0].ConnGater = gaterForPeer0
-	swarms[1].ConnGater = gaterForPeer1
-
-	swarms[1].Peerstore().AddAddr(swarms[0].LocalPeer(), swarms[0].ListenAddresses()[0], peerstore.PermanentAddrTTL)
-	_, err := swarms[1].DialPeer(ctx, swarms[0].LocalPeer())
-	if err == nil {
-		t.Fatal("dial should have failed")
-	}
-
-	swarms[0].Peerstore().AddAddr(swarms[1].LocalPeer(), swarms[1].ListenAddresses()[0], peerstore.PermanentAddrTTL)
-	_, err = swarms[0].DialPeer(ctx, swarms[1].LocalPeer())
-	if err == nil {
-		t.Fatal("dial should have failed")
-	}
-}*/
 
 func TestNoDial(t *testing.T) {
 	ctx := context.Background()

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -295,6 +295,7 @@ func TestConnectionGating(t *testing.T) {
 		"no gating": {
 			p1ConnectednessToP2: network.Connected,
 			p2ConnectednessToP1: network.Connected,
+			isP1OutboundErr:     false,
 		},
 		"p1 gates outbound peer dial": {
 			p1Gater: func(c *MockConnectionGater) *MockConnectionGater {
@@ -307,7 +308,7 @@ func TestConnectionGating(t *testing.T) {
 		},
 		"p1 gates outbound addr dialing": {
 			p1Gater: func(c *MockConnectionGater) *MockConnectionGater {
-				c.Dial = func(addr ma.Multiaddr) bool { return false }
+				c.Dial = func(p peer.ID, addr ma.Multiaddr) bool { return false }
 				return c
 			},
 			p1ConnectednessToP2: network.NotConnected,

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -370,6 +370,8 @@ func TestConnectionGating(t *testing.T) {
 		sw1.Peerstore().AddAddr(p2, sw2.ListenAddresses()[0], peerstore.PermanentAddrTTL)
 		// 1 -> 2
 		_, err := sw1.DialPeer(ctx, p2)
+		// give time for the swarm data structures to be updated
+		time.Sleep(100 * time.Millisecond)
 		require.Equal(t, tc.isP1OutboundErr, err != nil, n)
 		require.Equal(t, tc.p1ConnectednessToP2, sw1.Connectedness(p2), n)
 		require.Equal(t, tc.p2ConnectednessToP1, sw2.Connectedness(p1), n)

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/libp2p/go-libp2p-core/control"
+	"github.com/libp2p/go-libp2p-core/transport"
 	"io"
 	"sync"
 	"testing"
@@ -280,26 +282,101 @@ func TestConnHandler(t *testing.T) {
 	}
 }
 
-type mockGater struct {
-	addrs []ma.Multiaddr
-	p     peer.ID
-	dir   network.Direction
-}
+func TestConnectionGating(t *testing.T) {
+	ctx := context.Background()
+	tcs := map[string]struct {
+		p1Gater func(gater *MockConnectionGater) *MockConnectionGater
+		p2Gater func(gater *MockConnectionGater) *MockConnectionGater
 
-func (m *mockGater) DenyAddrConnection(addrs ma.Multiaddr) (deny bool) {
-	for _, a := range m.addrs {
-		if a == addrs {
-			return true
-		}
+		p1ConnectednessToP2 network.Connectedness
+		p2ConnectednessToP1 network.Connectedness
+		isP1OutboundErr     bool
+	}{
+		"no gating": {
+			p1ConnectednessToP2: network.Connected,
+			p2ConnectednessToP1: network.Connected,
+		},
+		"p1 gates outbound peer dial": {
+			p1Gater: func(c *MockConnectionGater) *MockConnectionGater {
+				c.PeerDial = func(p peer.ID) bool { return false }
+				return c
+			},
+			p1ConnectednessToP2: network.NotConnected,
+			p2ConnectednessToP1: network.NotConnected,
+			isP1OutboundErr:     true,
+		},
+		"p1 gates outbound addr dialing": {
+			p1Gater: func(c *MockConnectionGater) *MockConnectionGater {
+				c.Dial = func(addr ma.Multiaddr) bool { return false }
+				return c
+			},
+			p1ConnectednessToP2: network.NotConnected,
+			p2ConnectednessToP1: network.NotConnected,
+			isP1OutboundErr:     true,
+		},
+		"p2 gates inbound peer dial before securing": {
+			p2Gater: func(c *MockConnectionGater) *MockConnectionGater {
+				c.Accept = func(c network.ConnMultiaddrs) bool { return false }
+				return c
+			},
+			p1ConnectednessToP2: network.NotConnected,
+			p2ConnectednessToP1: network.NotConnected,
+			isP1OutboundErr:     true,
+		},
+		"p2 gates inbound peer dial before multiplexing": {
+			p1Gater: func(c *MockConnectionGater) *MockConnectionGater {
+				c.Secured = func(network.Direction, peer.ID, network.ConnMultiaddrs) bool { return false }
+				return c
+			},
+			p1ConnectednessToP2: network.NotConnected,
+			p2ConnectednessToP1: network.NotConnected,
+			isP1OutboundErr:     true,
+		},
+		"p2 gates inbound peer dial after upgrading": {
+			p1Gater: func(c *MockConnectionGater) *MockConnectionGater {
+				c.Upgraded = func(p transport.CapableConn) (bool, control.DisconnectReason) { return false, 0 }
+				return c
+			},
+			p1ConnectednessToP2: network.NotConnected,
+			p2ConnectednessToP1: network.NotConnected,
+			isP1OutboundErr:     true,
+		},
+		"p2 gates outbound dials": {
+			p2Gater: func(c *MockConnectionGater) *MockConnectionGater {
+				c.PeerDial = func(p peer.ID) bool { return false }
+				return c
+			},
+			p1ConnectednessToP2: network.Connected,
+			p2ConnectednessToP1: network.Connected,
+			isP1OutboundErr:     false,
+		},
 	}
-	return false
+
+	for n, tc := range tcs {
+		p1Gater := DefaultMockConnectionGater()
+		p2Gater := DefaultMockConnectionGater()
+		if tc.p1Gater != nil {
+			p1Gater = tc.p1Gater(p1Gater)
+		}
+		if tc.p2Gater != nil {
+			p2Gater = tc.p2Gater(p2Gater)
+		}
+
+		sw1 := GenSwarm(t, ctx, OptConnGater(p1Gater))
+		sw2 := GenSwarm(t, ctx, OptConnGater(p2Gater))
+
+		p1 := sw1.LocalPeer()
+		p2 := sw2.LocalPeer()
+		sw1.Peerstore().AddAddr(p2, sw2.ListenAddresses()[0], peerstore.PermanentAddrTTL)
+		// 1 -> 2
+		_, err := sw1.DialPeer(ctx, p2)
+		require.Equal(t, tc.isP1OutboundErr, err != nil, n)
+		require.Equal(t, tc.p1ConnectednessToP2, sw1.Connectedness(p2), n)
+		require.Equal(t, tc.p2ConnectednessToP1, sw2.Connectedness(p1), n)
+	}
 }
 
-func (m *mockGater) DenyPeerConnection(dir network.Direction, id peer.ID) bool {
-	return dir == m.dir && id == m.p
-}
-
-func TestPeerIdBlocking(t *testing.T) {
+/*func TestPeerIdBlocking(t *testing.T) {
 	// peer1 is not able to connect to peer2 because it gates outbound connections
 	// but peer2 is able to connect to peer1
 	ctx := context.Background()
@@ -355,37 +432,6 @@ func TestAddrBlocking(t *testing.T) {
 	_, err = swarms[0].DialPeer(ctx, swarms[1].LocalPeer())
 	if err == nil {
 		t.Fatal("dial should have failed")
-	}
-}
-
-// TODO NOT SKIP THIS
-/*
-func TestFilterBounds(t *testing.T) {
-	ctx := context.Background()
-	swarms := makeSwarms(ctx, t, 2)
-
-	conns := make(chan struct{}, 8)
-	swarms[0].SetConnHandler(func(conn network.Conn) {
-		conns <- struct{}{}
-	})
-
-	// Address that we wont be dialing from
-	_, block, err := net.ParseCIDR("192.0.0.1/8")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// set filter on both sides, shouldnt matter
-	swarms[1].Filters.AddDialFilter(block)
-	swarms[0].Filters.AddDialFilter(block)
-
-	connectSwarms(t, ctx, swarms)
-
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("should have gotten connection")
-	case <-conns:
-		t.Log("got connect")
 	}
 }*/
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -4,26 +4,31 @@ import (
 	"context"
 	"testing"
 
+	"github.com/libp2p/go-libp2p-core/connmgr"
+	"github.com/libp2p/go-libp2p-core/control"
 	"github.com/libp2p/go-libp2p-core/metrics"
 	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
-	"github.com/libp2p/go-libp2p-testing/net"
-	"github.com/libp2p/go-tcp-transport"
 
-	goprocess "github.com/jbenet/goprocess"
 	csms "github.com/libp2p/go-conn-security-multistream"
 	pstoremem "github.com/libp2p/go-libp2p-peerstore/pstoremem"
 	secio "github.com/libp2p/go-libp2p-secio"
+	swarm "github.com/libp2p/go-libp2p-swarm"
+	"github.com/libp2p/go-libp2p-testing/net"
 	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
 	yamux "github.com/libp2p/go-libp2p-yamux"
 	msmux "github.com/libp2p/go-stream-muxer-multistream"
+	"github.com/libp2p/go-tcp-transport"
 
-	swarm "github.com/libp2p/go-libp2p-swarm"
+	goprocess "github.com/jbenet/goprocess"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 type config struct {
 	disableReuseport bool
 	dialOnly         bool
+	connectionGater  connmgr.ConnectionGater
 }
 
 // Option is an option that can be passed when constructing a test swarm.
@@ -37,6 +42,13 @@ var OptDisableReuseport Option = func(_ *testing.T, c *config) {
 // OptDialOnly prevents the test swarm from listening.
 var OptDialOnly Option = func(_ *testing.T, c *config) {
 	c.dialOnly = true
+}
+
+// OptConnGater configures the given connection gater on the test
+func OptConnGater(cg connmgr.ConnectionGater) Option {
+	return func(_ *testing.T, c *config) {
+		c.connectionGater = cg
+	}
 }
 
 // GenUpgrader creates a new connection upgrader for use with this swarm.
@@ -53,9 +65,9 @@ func GenUpgrader(n *swarm.Swarm) *tptu.Upgrader {
 	stMuxer.AddTransport("/yamux/1.0.0", yamux.DefaultTransport)
 
 	return &tptu.Upgrader{
-		Secure:        secMuxer,
-		Muxer:         stMuxer,
-		AddrConnGater: n.ConnGater,
+		Secure:    secMuxer,
+		Muxer:     stMuxer,
+		ConnGater: n.ConnGater,
 	}
 
 }
@@ -76,6 +88,7 @@ func GenSwarm(t *testing.T, ctx context.Context, opts ...Option) *swarm.Swarm {
 	// Call AddChildNoWait because we can't call AddChild after the process
 	// may have been closed (e.g., if the context was canceled).
 	s.Process().AddChildNoWait(goprocess.WithTeardown(ps.Close))
+	s.ConnGater = cfg.connectionGater
 
 	tcpTransport := tcp.NewTCPTransport(GenUpgrader(s))
 	tcpTransport.DisableReuseport = cfg.disableReuseport
@@ -100,4 +113,58 @@ func DivulgeAddresses(a, b network.Network) {
 	id := a.LocalPeer()
 	addrs := a.Peerstore().Addrs(id)
 	b.Peerstore().AddAddrs(id, addrs, peerstore.PermanentAddrTTL)
+}
+
+// MockConnectionGater is a mock connection gater to be used by the tests.
+type MockConnectionGater struct {
+	Dial     func(p peer.ID, addr ma.Multiaddr) bool
+	PeerDial func(p peer.ID) bool
+	Accept   func(c network.ConnMultiaddrs) bool
+	Secured  func(network.Direction, peer.ID, network.ConnMultiaddrs) bool
+	Upgraded func(c network.Conn) (bool, control.DisconnectReason)
+}
+
+func DefaultMockConnectionGater() *MockConnectionGater {
+	m := &MockConnectionGater{}
+	m.Dial = func(p peer.ID, addr ma.Multiaddr) bool {
+		return true
+	}
+
+	m.PeerDial = func(p peer.ID) bool {
+		return true
+	}
+
+	m.Accept = func(c network.ConnMultiaddrs) bool {
+		return true
+	}
+
+	m.Secured = func(network.Direction, peer.ID, network.ConnMultiaddrs) bool {
+		return true
+	}
+
+	m.Upgraded = func(c network.Conn) (bool, control.DisconnectReason) {
+		return true, 0
+	}
+
+	return m
+}
+
+func (m *MockConnectionGater) InterceptAddrDial(p peer.ID, addr ma.Multiaddr) (allow bool) {
+	return m.Dial(p, addr)
+}
+
+func (m *MockConnectionGater) InterceptPeerDial(p peer.ID) (allow bool) {
+	return m.PeerDial(p)
+}
+
+func (m *MockConnectionGater) InterceptAccept(c network.ConnMultiaddrs) (allow bool) {
+	return m.Accept(c)
+}
+
+func (m *MockConnectionGater) InterceptSecured(d network.Direction, p peer.ID, c network.ConnMultiaddrs) (allow bool) {
+	return m.Secured(d, p, c)
+}
+
+func (m *MockConnectionGater) InterceptUpgraded(tc network.Conn) (allow bool, reason control.DisconnectReason) {
+	return m.Upgraded(tc)
 }

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -53,9 +53,9 @@ func GenUpgrader(n *swarm.Swarm) *tptu.Upgrader {
 	stMuxer.AddTransport("/yamux/1.0.0", yamux.DefaultTransport)
 
 	return &tptu.Upgrader{
-		Secure:  secMuxer,
-		Muxer:   stMuxer,
-		Filters: n.Filters,
+		Secure:        secMuxer,
+		Muxer:         stMuxer,
+		AddrConnGater: n.ConnGater,
 	}
 
 }


### PR DESCRIPTION
For https://github.com/libp2p/go-libp2p/issues/872.

Core PR at https://github.com/libp2p/go-libp2p-core/pull/139.
Upgrader PR at https://github.com/libp2p/go-libp2p-transport-upgrader/pull/55.

This PR uses the connection lifecycle state based Connection Gating interface to gate connections.