### PR TITLE
Initialize extra map in connections and streams Stat

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -214,7 +214,7 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 	}
 
 	// Wrap and register the connection.
-	stat := network.Stat{Direction: dir}
+	stat := network.Stat{Direction: dir, Extra: make(map[interface{}]interface{})}
 	c := &Conn{
 		conn:  tc,
 		swarm: s,

--- a/swarm_conn.go
+++ b/swarm_conn.go
@@ -185,7 +185,7 @@ func (c *Conn) addStream(ts mux.MuxedStream, dir network.Direction) (*Stream, er
 	}
 
 	// Wrap and register the stream.
-	stat := network.Stat{Direction: dir}
+	stat := network.Stat{Direction: dir, Extra: make(map[interface{}]interface{})}
 	s := &Stream{
 		stream: ts,
 		conn:   c,


### PR DESCRIPTION
Currently it seems like `Stat() Stat` API is broken - `Extra` map is always nil and devs have no possibility to use it. I am not sure is it a good idea to spend a few extra bytes on every stream, but this is talk for another PR I suppose, where we can discuss more flexible API.