### PR TITLE
feat: close transports that implement io.Closer

### DIFF
--- a/swarm_transport.go
+++ b/swarm_transport.go
@@ -20,7 +20,10 @@ func (s *Swarm) TransportForDialing(a ma.Multiaddr) transport.Transport {
 	s.transports.RLock()
 	defer s.transports.RUnlock()
 	if len(s.transports.m) == 0 {
-		log.Error("you have no transports configured")
+		// make sure we're not just shutting down.
+		if s.transports.m != nil {
+			log.Error("you have no transports configured")
+		}
 		return nil
 	}
 
@@ -48,7 +51,10 @@ func (s *Swarm) TransportForListening(a ma.Multiaddr) transport.Transport {
 	s.transports.RLock()
 	defer s.transports.RUnlock()
 	if len(s.transports.m) == 0 {
-		log.Error("you have no transports configured")
+		// make sure we're not just shutting down.
+		if s.transports.m != nil {
+			log.Error("you have no transports configured")
+		}
 		return nil
 	}
 
@@ -77,6 +83,9 @@ func (s *Swarm) AddTransport(t transport.Transport) error {
 
 	s.transports.Lock()
 	defer s.transports.Unlock()
+	if s.transports.m == nil {
+		return ErrSwarmClosed
+	}
 	var registered []string
 	for _, p := range protocols {
 		if _, ok := s.transports.m[p]; ok {

--- a/transport_test.go
+++ b/transport_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	swarm "github.com/libp2p/go-libp2p-swarm"
 	swarmt "github.com/libp2p/go-libp2p-swarm/testing"
 
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -14,6 +15,7 @@ import (
 type dummyTransport struct {
 	protocols []int
 	proxy     bool
+	closed    bool
 }
 
 func (dt *dummyTransport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (transport.CapableConn, error) {
@@ -35,13 +37,44 @@ func (dt *dummyTransport) Proxy() bool {
 func (dt *dummyTransport) Protocols() []int {
 	return dt.protocols
 }
+func (dt *dummyTransport) Close() error {
+	dt.closed = true
+	return nil
+}
 
 func TestUselessTransport(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	swarm := swarmt.GenSwarm(t, ctx)
-	err := swarm.AddTransport(new(dummyTransport))
+	s := swarmt.GenSwarm(t, ctx)
+	err := s.AddTransport(new(dummyTransport))
 	if err == nil {
 		t.Fatal("adding a transport that supports no protocols should have failed")
+	}
+}
+
+func TestTransportClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := swarmt.GenSwarm(t, ctx)
+	tpt := &dummyTransport{protocols: []int{1}}
+	if err := s.AddTransport(tpt); err != nil {
+		t.Fatal(err)
+	}
+	_ = s.Close()
+	if !tpt.closed {
+		t.Fatal("expected transport to be closed")
+	}
+
+}
+
+func TestTransportAfterClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := swarmt.GenSwarm(t, ctx)
+	s.Close()
+
+	tpt := &dummyTransport{protocols: []int{1}}
+	if err := s.AddTransport(tpt); err != swarm.ErrSwarmClosed {
+		t.Fatal("expected swarm closed error, got: ", err)
 	}
 }


### PR DESCRIPTION
This way, transports with shared resources (e.g., reused sockets) can clean them up. Otherwise, we have no way to tell, e.g., the QUIC transport to close it's socket "pool".

fixes https://github.com/libp2p/go-libp2p/issues/999