### PR TITLE
fix: handle case where swarm closes before stream

### DIFF
--- a/swarm_conn.go
+++ b/swarm_conn.go
@@ -87,12 +87,10 @@ func (c *Conn) doClose() {
 	}()
 }
 
-func (c *Conn) removeStream(s *Stream) bool {
+func (c *Conn) removeStream(s *Stream) {
 	c.streams.Lock()
-	_, has := c.streams.m[s]
 	delete(c.streams.m, s)
 	c.streams.Unlock()
-	return has
 }
 
 // listens for new streams.

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -440,3 +440,20 @@ func TestNoDial(t *testing.T) {
 		t.Fatal("should have failed with ErrNoConn")
 	}
 }
+
+func TestCloseWithOpenStreams(t *testing.T) {
+	ctx := context.Background()
+	swarms := makeSwarms(ctx, t, 2)
+	connectSwarms(t, ctx, swarms)
+
+	s, err := swarms[0].NewStream(ctx, swarms[1].LocalPeer())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	// close swarm before stream.
+	err = swarms[0].Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
When we close a connection, we set the "stream" set to nil to avoid opening new stream. Unfortunately, this meant we wouldn't decrement the reference count on the swarm.