### PR TITLE
prevent dialing addresses that we're listening on

### DIFF
--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -440,7 +440,7 @@ func (s *Swarm) filterKnownUndialables(p peer.ID, addrs []ma.Multiaddr) []ma.Mul
 	for _, addr := range lisAddrs {
 		protos := addr.Protocols()
 		// we're only sure about filtering out /ip4 and /ip6 addresses, so far
-		if len(protos) == 2 && (protos[0].Code == ma.P_IP4 || protos[0].Code == ma.P_IP6) {
+		if protos[0].Code == ma.P_IP4 || protos[0].Code == ma.P_IP6 {
 			ourAddrs = append(ourAddrs, addr)
 		}
 	}


### PR DESCRIPTION
It's impossible to run two nodes on the same IP:port, so we know for sure that any dial to an address that we're listening on will fail (as the peer IDs won't match).
In practice, this will be most useful for preventing dials to localhost for nodes that are listening on the default port.