### PR TITLE
Fix swarm transient connections logic

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -360,12 +360,6 @@ func (s *Swarm) NewStream(ctx context.Context, p peer.ID) (network.Stream, error
 			}
 		}
 
-		if c.Stat().Transient {
-			if useTransient, _ := network.GetUseTransient(ctx); !useTransient {
-				return nil, network.ErrTransientConn
-			}
-		}
-
 		s, err := c.NewStream(ctx)
 		if err != nil {
 			if c.conn.IsClosed() {

--- a/swarm_conn.go
+++ b/swarm_conn.go
@@ -177,6 +177,12 @@ func (c *Conn) Stat() network.Stat {
 
 // NewStream returns a new Stream from this connection
 func (c *Conn) NewStream(ctx context.Context) (network.Stream, error) {
+	if c.Stat().Transient {
+		if useTransient, _ := network.GetUseTransient(ctx); !useTransient {
+			return nil, network.ErrTransientConn
+		}
+	}
+
 	ts, err := c.conn.OpenStream(ctx)
 
 	if err != nil {


### PR DESCRIPTION
@vyzo Even the `conn.NewStream` function is exported and called in `Host`.