### PR TITLE
fix: use 64bit stream/conn IDs

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -47,15 +47,15 @@ var ErrDialTimeout = errors.New("dial timed out")
 // communication. The Chan sends/receives Messages, which note the
 // destination or source Peer.
 type Swarm struct {
+	nextConnID   uint64 // guarded by atomic
+	nextStreamID uint64 // guarded by atomic
+
 	// Close refcount. This allows us to fully wait for the swarm to be torn
 	// down before continuing.
 	refs sync.WaitGroup
 
 	local peer.ID
 	peers peerstore.Peerstore
-
-	nextConnID   uint32 // guarded by atomic
-	nextStreamID uint32 // guarded by atomic
 
 	conns struct {
 		sync.RWMutex
@@ -213,7 +213,7 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 		conn:  tc,
 		swarm: s,
 		stat:  stat,
-		id:    atomic.AddUint32(&s.nextConnID, 1),
+		id:    atomic.AddUint64(&s.nextConnID, 1),
 	}
 
 	// we ONLY check upgraded connections here so we can send them a Disconnect message.

--- a/swarm_conn.go
+++ b/swarm_conn.go
@@ -25,7 +25,7 @@ var ErrConnClosed = errors.New("connection closed")
 // Conn is the connection type used by swarm. In general, you won't use this
 // type directly.
 type Conn struct {
-	id    uint32
+	id    uint64
 	conn  transport.CapableConn
 	swarm *Swarm
 
@@ -209,7 +209,7 @@ func (c *Conn) addStream(ts mux.MuxedStream, dir network.Direction) (*Stream, er
 		stream: ts,
 		conn:   c,
 		stat:   stat,
-		id:     atomic.AddUint32(&c.swarm.nextStreamID, 1),
+		id:     atomic.AddUint64(&c.swarm.nextStreamID, 1),
 	}
 	c.streams.m[s] = struct{}{}
 

--- a/swarm_stream.go
+++ b/swarm_stream.go
@@ -17,7 +17,7 @@ var _ network.Stream = &Stream{}
 // Stream is the stream type used by swarm. In general, you won't use this type
 // directly.
 type Stream struct {
-	id uint32
+	id uint64
 
 	stream mux.MuxedStream
 	conn   *Conn


### PR DESCRIPTION
Given 1k requests per second (assuming one stream per request), we can easily loop around the stream ID after less than 2 months. 32bits is plenty (usually) for connection-scoped stream IDs because individual connections don't usually last that long, but isn't enough for a _global_ stream ID.

Given that there's no reason for these to be 32bit IDs, let's just make them 64bits.