### PR TITLE
remove incorrect call to InterceptAddrDial

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -212,16 +212,6 @@ func (s *Swarm) addConn(tc transport.CapableConn, dir network.Direction) (*Conn,
 		addr = tc.RemoteMultiaddr()
 	)
 
-	if s.gater != nil {
-		if allow := s.gater.InterceptAddrDial(p, addr); !allow {
-			err := tc.Close()
-			if err != nil {
-				log.Warnf("failed to close connection with peer %s and addr %s; err: %s", p.Pretty(), addr, err)
-			}
-			return nil, ErrAddrFiltered
-		}
-	}
-
 	// create the Stat object, initializing with the underlying connection Stat if available
 	var stat network.Stat
 	if cs, ok := tc.(network.ConnStat); ok {

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -317,6 +317,15 @@ func TestConnectionGating(t *testing.T) {
 			p2ConnectednessToP1: network.NotConnected,
 			isP1OutboundErr:     true,
 		},
+		"p2 accepts inbound peer dial if outgoing dial is gated": {
+			p2Gater: func(c *MockConnectionGater) *MockConnectionGater {
+				c.Dial = func(peer.ID, ma.Multiaddr) bool { return false }
+				return c
+			},
+			p1ConnectednessToP2: network.Connected,
+			p2ConnectednessToP1: network.Connected,
+			isP1OutboundErr:     false,
+		},
 		"p2 gates inbound peer dial before securing": {
 			p2Gater: func(c *MockConnectionGater) *MockConnectionGater {
 				c.Accept = func(c network.ConnMultiaddrs) bool { return false }


### PR DESCRIPTION
`addConn` is called both when we add a dialed and an accepted connection to the swarm. `InterceptAddrDial` is only supposed to intercept outgoing connections though. When dialing, we already call `InterceptAddrDial` when we compose the
list of dialable addresses: https://github.com/libp2p/go-libp2p-swarm/blob/eef02f818639129a7184dba4ac0dbba1471a4b40/swarm_dial.go#L658-L678