### PR TITLE
remove redundant self-dialing check, simplify starting of dialWorkerLoop

### DIFF
--- a/dial_sync.go
+++ b/dial_sync.go
@@ -8,8 +8,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-// DialWorerFunc is used by DialSync to spawn a new dial worker
-type dialWorkerFunc func(peer.ID, <-chan dialRequest) error
+// dialWorkerFunc is used by DialSync to spawn a new dial worker
+type dialWorkerFunc func(peer.ID, <-chan dialRequest)
 
 // newDialSync constructs a new DialSync
 func newDialSync(worker dialWorkerFunc) *DialSync {
@@ -93,12 +93,7 @@ func (ds *DialSync) getActiveDial(p peer.ID) (*activeDial, error) {
 			reqch:  make(chan dialRequest),
 			ds:     ds,
 		}
-
-		if err := ds.dialWorker(p, actd.reqch); err != nil {
-			cancel()
-			return nil, err
-		}
-
+		ds.dialWorker(p, actd.reqch)
 		ds.dials[p] = actd
 	}
 

--- a/dial_sync.go
+++ b/dial_sync.go
@@ -108,9 +108,9 @@ func (ds *DialSync) getActiveDial(p peer.ID) (*activeDial, error) {
 	return actd, nil
 }
 
-// DialLock initiates a dial to the given peer if there are none in progress
+// Dial initiates a dial to the given peer if there are none in progress
 // then waits for the dial to that peer to complete.
-func (ds *DialSync) DialLock(ctx context.Context, p peer.ID) (*Conn, error) {
+func (ds *DialSync) Dial(ctx context.Context, p peer.ID) (*Conn, error) {
 	ad, err := ds.getActiveDial(p)
 	if err != nil {
 		return nil, err

--- a/dial_sync.go
+++ b/dial_sync.go
@@ -93,7 +93,7 @@ func (ds *DialSync) getActiveDial(p peer.ID) (*activeDial, error) {
 			reqch:  make(chan dialRequest),
 			ds:     ds,
 		}
-		ds.dialWorker(p, actd.reqch)
+		go ds.dialWorker(p, actd.reqch)
 		ds.dials[p] = actd
 	}
 

--- a/dial_sync_test.go
+++ b/dial_sync_test.go
@@ -38,14 +38,14 @@ func TestBasicDialSync(t *testing.T) {
 
 	finished := make(chan struct{}, 2)
 	go func() {
-		if _, err := dsync.DialLock(context.Background(), p); err != nil {
+		if _, err := dsync.Dial(context.Background(), p); err != nil {
 			t.Error(err)
 		}
 		finished <- struct{}{}
 	}()
 
 	go func() {
-		if _, err := dsync.DialLock(context.Background(), p); err != nil {
+		if _, err := dsync.Dial(context.Background(), p); err != nil {
 			t.Error(err)
 		}
 		finished <- struct{}{}
@@ -74,7 +74,7 @@ func TestDialSyncCancel(t *testing.T) {
 
 	finished := make(chan struct{})
 	go func() {
-		_, err := dsync.DialLock(ctx1, p)
+		_, err := dsync.Dial(ctx1, p)
 		if err != ctx1.Err() {
 			t.Error("should have gotten context error")
 		}
@@ -90,7 +90,7 @@ func TestDialSyncCancel(t *testing.T) {
 
 	// Add a second dialwait in so two actors are waiting on the same dial
 	go func() {
-		_, err := dsync.DialLock(context.Background(), p)
+		_, err := dsync.Dial(context.Background(), p)
 		if err != nil {
 			t.Error(err)
 		}
@@ -123,7 +123,7 @@ func TestDialSyncAllCancel(t *testing.T) {
 
 	finished := make(chan struct{})
 	go func() {
-		if _, err := dsync.DialLock(ctx, p); err != ctx.Err() {
+		if _, err := dsync.Dial(ctx, p); err != ctx.Err() {
 			t.Error("should have gotten context error")
 		}
 		finished <- struct{}{}
@@ -131,7 +131,7 @@ func TestDialSyncAllCancel(t *testing.T) {
 
 	// Add a second dialwait in so two actors are waiting on the same dial
 	go func() {
-		if _, err := dsync.DialLock(ctx, p); err != ctx.Err() {
+		if _, err := dsync.Dial(ctx, p); err != ctx.Err() {
 			t.Error("should have gotten context error")
 		}
 		finished <- struct{}{}
@@ -155,7 +155,7 @@ func TestDialSyncAllCancel(t *testing.T) {
 
 	// should be able to successfully dial that peer again
 	done()
-	if _, err := dsync.DialLock(context.Background(), p); err != nil {
+	if _, err := dsync.Dial(context.Background(), p); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -188,12 +188,12 @@ func TestFailFirst(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	_, err := ds.DialLock(ctx, p)
+	_, err := ds.Dial(ctx, p)
 	if err == nil {
 		t.Fatal("expected gophers to have eaten the modem")
 	}
 
-	c, err := ds.DialLock(ctx, p)
+	c, err := ds.Dial(ctx, p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestStressActiveDial(t *testing.T) {
 
 	makeDials := func() {
 		for i := 0; i < 10000; i++ {
-			ds.DialLock(context.Background(), pid)
+			ds.Dial(context.Background(), pid)
 		}
 		wg.Done()
 	}
@@ -245,13 +245,13 @@ func TestDialSelf(t *testing.T) {
 	defer s.Close()
 
 	// this should fail
-	_, err := s.dsync.DialLock(ctx, self)
+	_, err := s.dsync.Dial(ctx, self)
 	if err != ErrDialToSelf {
 		t.Fatal("expected error from self dial")
 	}
 
 	// do it twice to make sure we get a new active dial object that fails again
-	_, err = s.dsync.DialLock(ctx, self)
+	_, err = s.dsync.Dial(ctx, self)
 	if err != ErrDialToSelf {
 		t.Fatal("expected error from self dial")
 	}

--- a/dial_test.go
+++ b/dial_test.go
@@ -672,7 +672,7 @@ func TestDialSimultaneousJoin(t *testing.T) {
 	}
 }
 
-func TestDialSelf2(t *testing.T) {
+func TestDialSelf(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/swarm.go
+++ b/swarm.go
@@ -122,7 +122,7 @@ func NewSwarm(ctx context.Context, local peer.ID, peers peerstore.Peerstore, bwc
 		}
 	}
 
-	s.dsync = newDialSync(s.startDialWorker)
+	s.dsync = newDialSync(s.dialWorkerLoop)
 	s.limiter = newDialLimiter(s.dialAddr)
 	s.proc = goprocessctx.WithContext(ctx)
 	s.ctx = goprocessctx.OnClosingContext(s.proc)

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -259,7 +259,7 @@ func (s *Swarm) dialPeer(ctx context.Context, p peer.ID) (*Conn, error) {
 	ctx, cancel := context.WithTimeout(ctx, network.GetDialPeerTimeout(ctx))
 	defer cancel()
 
-	conn, err = s.dsync.DialLock(ctx, p)
+	conn, err = s.dsync.Dial(ctx, p)
 	if err == nil {
 		return conn, nil
 	}

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -294,11 +294,7 @@ type dialResponse struct {
 	err  error
 }
 
-// startDialWorker starts an active dial goroutine that synchronizes and executes concurrent dials to a single peer
-func (s *Swarm) startDialWorker(p peer.ID, reqch <-chan dialRequest) {
-	go s.dialWorkerLoop(p, reqch)
-}
-
+// dialWorkerLoop synchronizes and executes concurrent dials to a single peer
 func (s *Swarm) dialWorkerLoop(p peer.ID, reqch <-chan dialRequest) {
 	defer s.limiter.clearAllPeerDials(p)
 

--- a/swarm_dial.go
+++ b/swarm_dial.go
@@ -294,14 +294,9 @@ type dialResponse struct {
 	err  error
 }
 
-// startDialWorker starts an active dial goroutine that synchronizes and executes concurrent dials
-func (s *Swarm) startDialWorker(p peer.ID, reqch <-chan dialRequest) error {
-	if p == s.local {
-		return ErrDialToSelf
-	}
-
+// startDialWorker starts an active dial goroutine that synchronizes and executes concurrent dials to a single peer
+func (s *Swarm) startDialWorker(p peer.ID, reqch <-chan dialRequest) {
 	go s.dialWorkerLoop(p, reqch)
-	return nil
 }
 
 func (s *Swarm) dialWorkerLoop(p peer.ID, reqch <-chan dialRequest) {


### PR DESCRIPTION
We already check for self dials in https://github.com/libp2p/go-libp2p-swarm/blob/a32e9937d6ec0d1a751a13d065d72ef1844aac5b/swarm_dial.go#L248-L250. We don't need to check again before starting the `dialWorkerLoop`. This allows us to get rid of the `error` return value.

Also, API-wise, it's always nice when the caller starts the go routine.