### PR TITLE
simplify limiter by removing the injected isFdConsumingFnc

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -123,7 +123,7 @@ func NewSwarm(ctx context.Context, local peer.ID, peers peerstore.Peerstore, bwc
 	}
 
 	s.dsync = newDialSync(s.startDialWorker)
-	s.limiter = newDialLimiter(s.dialAddr, isFdConsumingAddr)
+	s.limiter = newDialLimiter(s.dialAddr)
 	s.proc = goprocessctx.WithContext(ctx)
 	s.ctx = goprocessctx.OnClosingContext(s.proc)
 	s.backf.init(s.ctx)


### PR DESCRIPTION
The only reason to dependency-inject this function would be to use a different function in tests. Turns out that the mock implementation of this function in tests though was basically identical to the actual function.