### PR TITLE
add a test case for the testing package

### DIFF
--- a/testing/testing.go
+++ b/testing/testing.go
@@ -16,7 +16,7 @@ import (
 	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
 	quic "github.com/libp2p/go-libp2p-quic-transport"
 	swarm "github.com/libp2p/go-libp2p-swarm"
-	"github.com/libp2p/go-libp2p-testing/net"
+	tnet "github.com/libp2p/go-libp2p-testing/net"
 	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
 	yamux "github.com/libp2p/go-libp2p-yamux"
 	msmux "github.com/libp2p/go-stream-muxer-multistream"
@@ -86,7 +86,6 @@ func GenUpgrader(n *swarm.Swarm) *tptu.Upgrader {
 		Secure: secMuxer,
 		Muxer:  stMuxer,
 	}
-
 }
 
 // GenSwarm generates a new test swarm.

--- a/testing/testing_test.go
+++ b/testing/testing_test.go
@@ -1,0 +1,14 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenSwarm(t *testing.T) {
+	swarm := GenSwarm(t, context.Background())
+	require.NoError(t, swarm.Close())
+	GenUpgrader(swarm)
+}


### PR DESCRIPTION
The CI upgrade in https://github.com/libp2p/go-libp2p-circuit/pull/137 failed because the `testing` package here pulls in an outdated version of go-libp2p-quic-transport. This should have been caught in the PR updating the workflow files in this repo, but hasn't, since the code in the `testing` package here is never run.