### PR TITLE
send notifications synchronously

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -506,18 +506,10 @@ func (s *Swarm) Backoff() *DialBackoff {
 
 // notifyAll sends a signal to all Notifiees
 func (s *Swarm) notifyAll(notify func(network.Notifiee)) {
-	var wg sync.WaitGroup
-
 	s.notifs.RLock()
-	wg.Add(len(s.notifs.m))
 	for f := range s.notifs.m {
-		go func(f network.Notifiee) {
-			defer wg.Done()
-			notify(f)
-		}(f)
+		notify(f)
 	}
-
-	wg.Wait()
 	s.notifs.RUnlock()
 }
 


### PR DESCRIPTION
`notifyAll` is creating a lot of allocations (and therefore pressure on the GC) by notifying async:

`-gcflags=-m` confirms why notifyAll is pretty allocation-heavy:
```
./swarm.go:508:7: leaking param: s
./swarm.go:508:27: leaking param: notify
./swarm.go:514:11: leaking param: f
./swarm.go:509:6: moved to heap: wg
./swarm.go:514:6: func literal escapes to heap
```

Note that there's been some discussion about this a long time ago: https://github.com/libp2p/go-libp2p-swarm/pull/104#issuecomment-465095630. I'd argue though that if there's one misbehaving consumer, we have a problem no matter if we send the notifications sync or async, as `notifyAll` still waits for all notifications to be processed.
The real question therefore is if the cost of spawning the go routines is less than what we gain from handling these notifications handled concurrently.

Thanks to @mvdan for his help debugging this.