### PR TITLE
release the stream scope if the conn fails to open a new stream

### DIFF
--- a/swarm_conn.go
+++ b/swarm_conn.go
@@ -199,6 +199,7 @@ func (c *Conn) NewStream(ctx context.Context) (network.Stream, error) {
 	}
 	ts, err := c.conn.OpenStream(ctx)
 	if err != nil {
+		scope.Done()
 		return nil, err
 	}
 	return c.addStream(ts, network.DirOutbound, scope)


### PR DESCRIPTION
this clogs the transient scope in lotus, as first observed in magik's markets node.